### PR TITLE
Allow domain override in Docker Compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -20,7 +20,7 @@ services:
       MYSQL_SERVER_USER_NAME: "root"
       REDIS_HOST: "app_redis"
       REDIS_ENABLED: true
-      DOMAIN: "localhost"
+      DOMAIN: "${DOMAIN:-localhost}"
     user: "${DOCKER_USER}"
 
   mysql-server:


### PR DESCRIPTION
This allows to override the domain using an environment variable. This is useful when running the project on a remote machine (e.g. using GitHub Codespaces).