### PR TITLE
Don't double count Emperor Palpatine unit and leader

### DIFF
--- a/AllyAbilities.php
+++ b/AllyAbilities.php
@@ -72,7 +72,17 @@ function AllyStaticHealthModifier($cardID, $index, $player, $myCardID, $myIndex)
       break;
     case "9097316363"://Emperor Palpatine
     case "6c5b96c7ef"://Emperor Palpatine
-      if($cardID == "1780978508") return 1;//Royal Guard
+      if($cardID == "1780978508") { //Royal Guard
+        $isEmperorPalpatineLeader = false;
+        $character = &GetPlayerCharacter($player);
+        for($i=0; $i<count($character); $i+=CharacterPieces()) {
+          if($character[$i] == "5784497124") { //Emperor Palpatine
+            $isEmperorPalpatineLeader = true;
+            break;
+          }
+        }
+        return $isEmperorPalpatineLeader ? 0 : 1;
+      }
       break;
     default: break;
   }


### PR DESCRIPTION
The Emperor Royal Guards health was buffed more than once you controlled Emperor Palpatine as a leader as well as Emperor Palpatine as a unit (for a total of +3 if you controlled `Emperor Palpatine, Galatic Ruler (leader)`, `Emperor Palpatine, Galatic Ruler (unit)` and `Emperor Palpatine, Master of the Dark Side`).

This fix prevents buffing the health from controlling Emperor Palpatine as a unit if Emperor Palpatine is already a leader. Note that if a new version of Emperor Palpatine unit is released, this will still be wrong when the leader is not Emperor Palpatine but it works fine with the current card pool.