### PR TITLE
97th legion health

### DIFF
--- a/AllyAbilities.php
+++ b/AllyAbilities.php
@@ -17,6 +17,7 @@ function PlayAlly($cardID, $player, $subCards = "-", $from="-")
   array_push($allies, 0); //Times attacked
   array_push($allies, $player); //Owner
   array_push($allies, 0); //Turns in play
+  array_push($allies, $player); //Controller
   $index = count($allies) - AllyPieces();
   CurrentEffectAllyEntersPlay($player, $index);
   AllyEntersPlayAbilities($player);
@@ -232,6 +233,9 @@ function AllyHealth($cardID, $playerID="")
   $health = CardHP($cardID);
   switch($cardID)
   {
+    case "7648077180"://97th Legion
+      $health += NumResources($playerID);
+      break;
     default: break;
   }
   return $health;

--- a/Classes/Ally.php
+++ b/Classes/Ally.php
@@ -48,6 +48,7 @@ class Ally {
     return $this->allies[$this->index+11];
   }
 
+  function Controller() {
     return $this->allies[$this->index+13];
   }
 

--- a/Classes/Ally.php
+++ b/Classes/Ally.php
@@ -48,6 +48,9 @@ class Ally {
     return $this->allies[$this->index+11];
   }
 
+    return $this->allies[$this->index+13];
+  }
+
   function TurnsInPlay() {
     global $currentRound;
     if(IsLeader($this->CardID(), $this->PlayerID())) return $currentRound - 1;

--- a/Constants.php
+++ b/Constants.php
@@ -127,9 +127,10 @@ function ResourcePieces() { return ArsenalPieces(); }
 //10 - Times Attacked
 //11 - Owner
 //12 - Turns in play
+//13 - Controller
 function AllyPieces()
 {
-  return 13;
+  return 14;
 }
 
 //Card ID

--- a/CoreLogic.php
+++ b/CoreLogic.php
@@ -3365,11 +3365,6 @@ function PlayAbility($cardID, $from, $resourcesPaid, $target = "-", $additionalC
         AddDecisionQueue("ADDLIMITEDCURRENTEFFECT", $currentPlayer, "1939951561_" . $i . ",PLAY", 1);
       }
       break;
-    case "7648077180"://97th Legion
-      if($from != "PLAY") {
-        $playAlly->AddHealth(NumResources($currentPlayer));
-      }
-      break;
     case "2202839291"://Don't Get Cocky
       AddDecisionQueue("PASSPARAMETER", $currentPlayer, $target);
       AddDecisionQueue("SETDQVAR", $currentPlayer, 0);


### PR DESCRIPTION
This moves the health calculation for 97th leigion to be present on play. Also adds a "Controller" field to keep track of who is controlling a unit.