### PR TITLE
Fix for non-selectable inputs in Safari browser

### DIFF
--- a/css/karabast.css
+++ b/css/karabast.css
@@ -137,6 +137,7 @@ select {
   border-radius: 10px;
   padding: 20px;
   backdrop-filter: blur(20px);
+  -webkit-backdrop-filter: blur(20px);
   scrollbar-color: #888888 rgba(0, 0, 0, 0); 
   scrollbar-width: thin;
 }


### PR DESCRIPTION
Apparently Safari needs its own specific background blur, and breaks things without it.