### PR TITLE
Fix docker first run issues

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,5 @@
+# Set the default behavior, in case people don't have core.autocrlf set.
+* text=auto
+
+# set lf eol to avoid windows docker adding an extra character to the folder name
+docker-entrypoint.sh text eol=lf

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,3 +1,4 @@
 mkdir SWUOnline/HostFiles
 cp SWUOnline/docker/* SWUOnline/HostFiles
+mkdir SWUOnline/Games
 apache2-foreground


### PR DESCRIPTION
Resolving a couple problems I encountered doing a first run with docker on Windows:

- The entrypoint script was using crlf line endings by default, so the `HostFiles` dir had a CR character at the end of the name which broke the server. Added a .gitattributes to resolve this automatically in the future
- The Games folder wasn't created at launch, causing a (benign) error message