### PR TITLE
Automatic support for xdebug in local docker run

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,5 @@
 
 Games
 HostFiles
-HostFiles/GameIDCounter.txt
-HostFiles/GameIDCounter.txt
 .DS_Store
 .env

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,17 @@
+{
+    // Use IntelliSense to learn about possible attributes.
+    // Hover to view descriptions of existing attributes.
+    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "name": "SWUOnline: Listen for Xdebug",
+            "type": "php",
+            "request": "launch",
+            "port": 9003,
+            "pathMappings": {
+                "/var/www/html/SWUOnline": "${workspaceFolder}",
+            }
+        }
+    ]
+}

--- a/DevTools/xdebug/error_reporting.ini
+++ b/DevTools/xdebug/error_reporting.ini
@@ -1,0 +1,1 @@
+error_reporting=E_ALL

--- a/DevTools/xdebug/xdebug.ini
+++ b/DevTools/xdebug/xdebug.ini
@@ -1,0 +1,6 @@
+zend_extension=xdebug
+
+[xdebug]
+xdebug.mode=develop,debug
+xdebug.discover_client_host = 1
+xdebug.start_with_request=yes

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,10 @@
-FROM php:8.2.1-apache
-RUN apt-get update && apt-get install -y libbz2-dev
-RUN apt-get update && apt-get install -y libc-client-dev libkrb5-dev && rm -r /var/lib/apt/lists/*
-RUN apt-get update && apt-get install -y libxslt-dev
-RUN apt-get install -y libzip-dev
+FROM php:8.2.1-apache as base
+RUN apt-get update && apt-get install -y --no-install-recommends libbz2-dev \
+    libc-client-dev \
+    libkrb5-dev \
+    libxslt-dev \
+    libzip-dev && \
+    rm -r /var/lib/apt/lists/*
 
 RUN docker-php-ext-configure imap --with-kerberos --with-imap-ssl \
     && docker-php-ext-install imap
@@ -10,7 +12,16 @@ RUN docker-php-ext-configure imap --with-kerberos --with-imap-ssl \
 RUN pecl install -o -f redis \
     &&  rm -rf /tmp/pear \
     &&  docker-php-ext-enable redis
+
 RUN docker-php-ext-install zip mysqli pdo pdo_mysql shmop bz2
 
 # use sed to change individual php.ini settings here
 RUN cp /usr/local/etc/php/php.ini-development /usr/local/etc/php/php.ini
+
+# this layer will only build if we add --target=build to the docker build command
+FROM base as dev
+RUN pecl install xdebug && \
+    docker-php-ext-enable xdebug
+
+# this layer builds by default and just has the base packages
+FROM base as prod

--- a/README.md
+++ b/README.md
@@ -1,29 +1,42 @@
 # SWUOnline
 Star Wars Unlimited Sim
 
-## Docker environment
-### Configuration
+## Docker environment with live debugging
+We provide a docker environment for local run with built-in xdebug support for live debugging. A preconfigured setup is provided for Visual Studio Code (it would be very simple to set up other tools as well).
+
+### Step 1. Configuration (optional in Docker for Windows)
+_(Docker Desktop for Windows will handle user permissions automatically without this step.)_
+
 Create a .env file in the root directory with the contents of the .env.dist file.
-And set the values of the variables.
+And set the value of the DOCKER_USER with the result of these commands:
 
-DOCKER_USER with the result of the commands 
-userId:
-```bash id -u```
-groupId:
-```bash id -g```
+```bash
+bash id -u  # user id
+bash id -g  # group id
+```
 
-DOCKER_USER=$userId:$groupId
+Use the format `DOCKER_USER=$userId:$groupId`. For example, `DOCKER_USER=1000:1000`.
 
-### Starting environment
+### 2. Starting / stopping the service
 
-Run the following command to start the environment
-```bash docker compose up -d```
+Run the following commands to start / stop the service
+```bash
+bash docker compose up -d   # start
+bash docker compose down    # stop
+bash docker compose restart # restart
+```
 
-### Stopping environment
-run the following command to stop the environment
-```bash docker compose down```
+### 3. Accessing the application
 
-### Accessing the application
+Open this address in your browser: http://localhost:8080/SWUOnline/MainMenu.php
 
-open in your browser the address
-```http://localhost:8080/SWUOnline/MainMenu.php```
+If you want to play a game against yourself, open multiple windows / tabs and connect.
+
+### 4. Run debugger in VSCode (optional)
+Xdebug is already running in the service, you can use these steps to do live debugging with breakpoints in Visual Studio Code:
+
+1. Install an extension that supports PHP debugging, such as https://marketplace.visualstudio.com/items?itemName=DEVSENSE.phptools-vscode
+2. We have a preconfigured [launch.json](.vscode/launch.json) to enable the debug action. In the vscode debug window (Ctrl + Shift + D), select the configuration `SWUOnline: Listen for Xdebug` and hit the Run button.
+3. You are now connected for debugging, add a breakpoint and try it out :)
+
+Additionally, any tool that can connect to xdebug remotely should work as well.

--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -1,0 +1,14 @@
+# this file holds debug-specific settings for docker-compose launch
+# by default, docker-compose.override.yml will be merged with docker-compose.yml for docker compose commands (see https://docs.docker.com/compose/multiple-compose-files/merge/#additional-information)
+# to run without the debug settings (i.e. to mirror the live configuration), use docker-compose -f docker-compose.yml
+version: "3.7"
+services:
+  web-server:
+    build:
+      target: dev
+    volumes:
+      - "./DevTools/xdebug/xdebug.ini:/usr/local/etc/php/conf.d/docker-php-ext-xdebug.ini:Z"
+      - "./DevTools/xdebug/error_reporting.ini:/usr/local/etc/php/conf.d/error_reporting.ini:Z"
+    environment:
+      XDEBUG_MODE: debug
+      XDEBUG_CONFIG: client_host=host.docker.internal client_port=9003

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,7 +6,7 @@ services:
       context: .
     restart: always
     volumes:
-      - "./:/var/www/html/SWUOnline"
+      - "./:/var/www/html/SWUOnline:Z"
     command: bash "/var/www/html/SWUOnline/docker-entrypoint.sh"
     ports:
       - "8080:80"

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,4 +1,3 @@
 mkdir SWUOnline/HostFiles
 cp SWUOnline/docker/* SWUOnline/HostFiles
-mkdir SWUOnline/Games
 apache2-foreground


### PR DESCRIPTION
Updated the local docker-compose build and run so that xdebug will be automatically enabled without additional effort. Added a launch.json file for vscode which enables one-push live debugging.

Since I was changing the dockerfile anyway, I cleaned up the layers a little bit to reduce the size.

Still having some weird issues with file permissions, did further updates and I think it is fixed now.