### PR TITLE
Fix stolen landspeeder

### DIFF
--- a/AllyAbilities.php
+++ b/AllyAbilities.php
@@ -631,13 +631,7 @@ function CollectBounty($player, $index, $cardID, $reportMode=false, $bountyUnitO
     case "7642980906"://Stolen Landspeeder
       ++$numBounties;
       if($reportMode) break;
-      if($ally->Owner() == $opponent) {
-        AddDecisionQueue("MULTIZONEINDICES", $opponent, "MYDISCARD:cardID=" . $cardID);
-        AddDecisionQueue("SETDQCONTEXT", $opponent, "Click the Stolen Landspeeder to play it for free.", 1);
-        AddDecisionQueue("MAYCHOOSEMULTIZONE", $opponent, "<-", 1);
-        AddDecisionQueue("ADDCURRENTEFFECT", $opponent, $cardID, 1);//Cost discount and experience adding.
-        AddDecisionQueue("MZOP", $opponent, "PLAYCARD", 1);
-      }
+      if($ally->Owner() == $opponent) AddLayer("TRIGGER", $opponent, "7642980906");
       break;
     case "9642863632"://Bounty Hunter's Quarry
       ++$numBounties;

--- a/AllyAbilities.php
+++ b/AllyAbilities.php
@@ -145,17 +145,6 @@ function DestroyAlly($player, $index, $skipDestroy = false, $fromCombat = false)
   $allies = &GetAllies($player);
   $cardID = $allies[$index];
   if(!$skipDestroy) {
-    if($cardID == "7642980906") {//Stolen Landspeeder
-      $ally = new Ally("MYALLY-" . $index, $player);
-      if($player != $ally->Owner()) {
-        $ally->Attach("2007868442");//Experience token
-        $ally->Heal(999);
-        $otherPlayer = $player == 1 ? 2 : 1;
-        AddDecisionQueue("PASSPARAMETER", $otherPlayer, "THEIRALLY-" . $ally->Index(), 1);
-        AddDecisionQueue("MZOP", $otherPlayer, "TAKECONTROL", 1);
-        return $cardID;
-      }
-    }
     AllyDestroyedAbility($player, $index, $fromCombat);
     CollectBounties($player, $index);
     IncrementClassState($player, $CS_NumAlliesDestroyed);
@@ -176,7 +165,7 @@ function DestroyAlly($player, $index, $skipDestroy = false, $fromCombat = false)
   $owner = $allies[$index+11];
   if(!$skipDestroy) {
     if(DefinedTypesContains($cardID, "Leader", $player)) ;//If it's a leader it doesn't go in the discard
-    else if($cardID == "8954587682" && !$ally->LostAbilities()) AddResources($cardID, $player, "PLAY", "DOWN");
+    else if($cardID == "8954587682" && !$ally->LostAbilities()) AddResources($cardID, $player, "PLAY", "DOWN");//Superlaser Technician
     else if($cardID == "7204838421" && !$ally->LostAbilities()) AddResources($cardID, $player, "PLAY", "DOWN");//Enterprising Lackeys
     else AddGraveyard($cardID, $owner, "PLAY");
   }
@@ -585,11 +574,6 @@ function CollectBounty($player, $index, $cardID, $reportMode=false, $bountyUnitO
         ReadyResource($opponent);
       }
       break;
-    case "6878039039"://Hylobon Enforcer
-      ++$numBounties;
-      if($reportMode) break;
-      Draw($opponent);
-      break;
     case "6420322033"://Enticing Reward
       ++$numBounties;
       if($reportMode) break;
@@ -610,6 +594,8 @@ function CollectBounty($player, $index, $cardID, $reportMode=false, $bountyUnitO
       if(!CardIsUnique($bountyUnit)) PummelHit($opponent);
       break;
     case "9503028597"://Clone Deserter
+    case "9108611319"://Cartel Turncoat
+    case "6878039039"://Hylobon Enforcer
       ++$numBounties;
       if($reportMode) break;
       Draw($opponent);
@@ -635,11 +621,6 @@ function CollectBounty($player, $index, $cardID, $reportMode=false, $bountyUnitO
       AddDecisionQueue("MAYCHOOSEMULTIZONE", $opponent, "<-", 1);
       AddDecisionQueue("MZOP", $opponent, "REST", 1);
       break;
-    case "9108611319"://Cartel Turncoat
-      ++$numBounties;
-      if($reportMode) break;
-      Draw($opponent);
-      break;
     case "0252207505"://Synara San
       if($bountyUnitOverride != "-" || $ally->IsExhausted()) {
         ++$numBounties;
@@ -650,6 +631,13 @@ function CollectBounty($player, $index, $cardID, $reportMode=false, $bountyUnitO
     case "7642980906"://Stolen Landspeeder
       ++$numBounties;
       if($reportMode) break;
+      if($ally->Owner() == $opponent) {
+        AddDecisionQueue("MULTIZONEINDICES", $opponent, "MYDISCARD:cardID=" . $cardID);
+        AddDecisionQueue("SETDQCONTEXT", $opponent, "Click the Stolen Landspeeder to play it for free.", 1);
+        AddDecisionQueue("MAYCHOOSEMULTIZONE", $opponent, "<-", 1);
+        AddDecisionQueue("ADDCURRENTEFFECT", $opponent, $cardID, 1);//Cost discount and experience adding.
+        AddDecisionQueue("MZOP", $opponent, "PLAYCARD", 1);
+      }
       break;
     case "9642863632"://Bounty Hunter's Quarry
       ++$numBounties;

--- a/CardLogic.php
+++ b/CardLogic.php
@@ -626,6 +626,15 @@ function ProcessTrigger($player, $parameter, $uniqueID, $target="-")
       AddDecisionQueue("SETDQCONTEXT", $player, "Choose a card to play");
       AddDecisionQueue("MAYCHOOSEMULTIZONE", $player, "<-", 1);
       AddDecisionQueue("MZOP", $player, "PLAYCARD", 1);
+      break;
+    case "7642980906"://Stolen Landspeeder
+      AddDecisionQueue("MULTIZONEINDICES", $player, "MYDISCARD:cardID=" . "7642980906");
+      AddDecisionQueue("SETDQCONTEXT", $player, "Click the Stolen Landspeeder to play it for free.", 1);
+      AddDecisionQueue("MAYCHOOSEMULTIZONE", $player, "<-", 1);
+      AddDecisionQueue("ADDCURRENTEFFECT", $player, "7642980906", 1);//Cost discount and experience adding.
+      AddDecisionQueue("MZOP", $player, "PLAYCARD", 1);
+      AddDecisionQueue("REMOVECURRENTEFFECT", $player, "7642980906");
+      break;
     default: break;
   }
 }

--- a/CardSetters.php
+++ b/CardSetters.php
@@ -459,7 +459,7 @@ function RemoveCharacterEffects($player, $index, $effect)
 
 function AddSpecificGraveyard($cardID, &$graveyard, $from, $player, $modifier="-")
 {
-  if($cardID == "3991112153" && ($from == "HAND" || $from == "DECK")) $modifier = "TT";
+  if($cardID == "3991112153" && ($from == "HAND" || $from == "DECK")) $modifier = "TT";//Kylo's TIE Silencer
   array_push($graveyard, $cardID);
   array_push($graveyard, $modifier);
 }

--- a/CurrentEffectAbilities.php
+++ b/CurrentEffectAbilities.php
@@ -305,6 +305,9 @@ function CurrentEffectCostModifiers($cardID, $from, $reportMode=false)
           $costModifier -= 2;
           $remove = true;
           break;
+        case "7642980906"://Stolen Landspeeder
+          $costModifier -= 99;
+          $remove = false;
         default: break;
       }
       if($remove && !$reportMode) RemoveCurrentTurnEffect($i);
@@ -716,13 +719,10 @@ function CurrentEffectAllyEntersPlay($player, $index)
     $remove = false;
     if($currentTurnEffects[$i + 1] == $player) {
       switch($currentTurnEffects[$i]) {
-        case "RfPP8h16Wv":
-          if(SubtypeContains($allies[$index], "BEAST", $player) || SubtypeContains($allies[$index], "ANIMAL", $player))
-          {
-            ++$allies[$index+2];
-            ++$allies[$index+7];
-            $remove = 1;
-          }
+        case "7642980906"://Stolen Landspeeder
+          $ally = new Ally("MYALLY-" . $index, $player);
+          $ally->Attach("2007868442");//Experience token
+          RemoveCurrentTurnEffect($i);
           break;
         default:
           break;

--- a/CurrentEffectAbilities.php
+++ b/CurrentEffectAbilities.php
@@ -720,9 +720,9 @@ function CurrentEffectAllyEntersPlay($player, $index)
     if($currentTurnEffects[$i + 1] == $player) {
       switch($currentTurnEffects[$i]) {
         case "7642980906"://Stolen Landspeeder
+          $remove = true;
           $ally = new Ally("MYALLY-" . $index, $player);
           $ally->Attach("2007868442");//Experience token
-          RemoveCurrentTurnEffect($i);
           break;
         default:
           break;


### PR DESCRIPTION
Reimplemented Stolen Landspeeder to fix a bug I found where killing it with Bossk's ability would have the opponent(of the owner) get it with the experience token. The way it works now is more in line with the rules too(triggers like other bounties, and is actually played from the discard).