### PR TITLE
Add SW-Unlimited-db logic

### DIFF
--- a/JoinGameInput.php
+++ b/JoinGameInput.php
@@ -120,6 +120,19 @@ if ($decklink != "") {
     $json = $apiDeck;
     echo($json);
   }
+  else if(str_contains($decklink, "sw-unlimited-db.com/decks")) {
+    $decklinkArr = explode("/", $decklink);
+	  $deckId = trim($decklinkArr[count($decklinkArr) - 1]);
+    $curl = curl_init();
+    curl_setopt($curl, CURLOPT_URL, "https://sw-unlimited-db.com/umbraco/api/deckapi/get?id=" . $deckId);
+    curl_setopt($curl, CURLOPT_RETURNTRANSFER, 1);
+    $apiDeck = curl_exec($curl);
+    $apiInfo = curl_getinfo($curl);
+    $errorMessage = curl_error($curl);
+    curl_close($curl);
+    $json = $apiDeck;
+    echo($json);
+  }
   else $json = $decklink;
 
   if($json == "") {

--- a/MainMenu.php
+++ b/MainMenu.php
@@ -34,6 +34,7 @@ $createGameText = ($language == 1 ? "Create Game" : "ゲームを作る");
 $languageText = ($language == 1 ? "Language" : "言語");
 $createNewGameText = ($language == 1 ? "Create New Game" : "新しいゲームを作成する");
 $starterDecksText = ($language == 1 ? "Starter Decks" : "おすすめデッキ");
+$deckUrl = TryGet("deckUrl", '');
 
 $canSeeQueue = isset($_SESSION["useruid"]);
 
@@ -93,8 +94,8 @@ include_once 'Header.php';
   */
 
   ?>
-  <label for="fabdb"><u><a style='color:lightblue;' href='https://www.swudb.com/' target='_blank'>SWUDB</a></u> Deck Link <span class="secondary">(use the url or 'Deck Link' button)</span></label>
-  <input type="text" id="fabdb" name="fabdb">
+  <label for="fabdb"><u><a style='color:lightblue;' href='https://www.swudb.com/' target='_blank'>SWUDB</a></u> or <u><a style='color:lightblue;' href='https://www.sw-unlimited-db.com/' target='_blank'>SW-Unlimited-DB</a></u> Deck Link <span class="secondary">(use the url or 'Deck Link' button)</span></label>
+  <input type="text" id="fabdb" name="fabdb" value='<?= $deckUrl ?>'>
   <?php
   if (isset($_SESSION["userid"])) {
     echo ("<span class='save-deck'>");


### PR DESCRIPTION
Adds the following two things:
- Ability to use SW-Unlimited-DB deck urls in the deck url input.
- Ability to prefill the deck url input through the url. This will allow me to add a "Try on Karabast" link on every deck page