### PR TITLE
feat: randomness improved

### DIFF
--- a/GameLogic.php
+++ b/GameLogic.php
@@ -772,9 +772,9 @@ function DecisionQueueStaticEffect($phase, $player, $parameter, $lastResult)
     case "SHUFFLEDECK":
       $zone = &GetDeck($player);
       $destArr = [];
-      if($parameter == "SKIPSEED") { global $randomSeeded; $randomSeeded = true; }
+      $skipSeed = $parameter == "SKIPSEED";
       while(count($zone) > 0) {
-        $index = GetRandom(0, count($zone) - 1);
+        $index = GetRandom(0, count($zone) - 1, $skipSeed);
         $destArr[] = $zone[$index];
         unset($zone[$index]);
         $zone = array_values($zone);

--- a/Libraries/CoreLibraries.php
+++ b/Libraries/CoreLibraries.php
@@ -23,7 +23,12 @@ function RandomizeArray(&$arr)
 function GetRandom($low=-1, $high=-1)
 {
   global $randomSeeded;
-  if(!$randomSeeded) SeedRandom();
+  if($randomSeeded) {
+    $low = $low == -1 ? 0 : $low;
+    $high = $high == -1 ? mt_getrandmax() : $high;
+    return random_int($low, $high);
+  } else SeedRandom();
+
   if($low == -1) return mt_rand();
   return mt_rand($low, $high);
 }

--- a/Libraries/CoreLibraries.php
+++ b/Libraries/CoreLibraries.php
@@ -20,14 +20,16 @@ function RandomizeArray(&$arr)
   }
 }
 
-function GetRandom($low=-1, $high=-1)
+function GetRandom($low=-1, $high=-1, $skipSeed=false)
 {
-  global $randomSeeded;
-  if($randomSeeded) {
+  if($skipSeed) {
     $low = $low == -1 ? 0 : $low;
     $high = $high == -1 ? mt_getrandmax() : $high;
     return random_int($low, $high);
-  } else SeedRandom();
+  }
+
+  global $randomSeeded;
+  if(!$randomSeeded) SeedRandom();
 
   if($low == -1) return mt_rand();
   return mt_rand($low, $high);


### PR DESCRIPTION
### Improved randomness when shuffling the deck

- Changed `mt_rand` to `random_int`.
`random_int` is better than `mt_rand` in PHP for higher randomness because it uses a cryptographic random number generator, providing stronger unpredictability. `mt_rand` uses the Mersenne Twister algorithm, which is not suitable for cryptographic purposes. Regarding seeds, `random_int` relies on sources like /dev/urandom or CryptGenRandom, ensuring better randomness without manual seeding.