### PR TITLE
More Bug Fixes & Trigger Improvements

### DIFF
--- a/AllyAbilities.php
+++ b/AllyAbilities.php
@@ -63,8 +63,6 @@ function AllyHasStaticHealthModifier($cardID)
     case "1557302740"://General Veers
     case "9799982630"://General Dodonna
     case "4339330745"://Wedge Antilles
-    case "9097316363"://Emperor Palpatine
-    case "6c5b96c7ef"://Emperor Palpatine
     case "4511413808"://Follower of the Way
     case "3731235174"://Supreme Leader Snoke
     case "6097248635"://4-LOM
@@ -87,20 +85,6 @@ function AllyStaticHealthModifier($cardID, $index, $player, $myCardID, $myIndex,
     case "4339330745"://Wedge Antilles
       if($index != $myIndex && $player == $myPlayer && TraitContains($cardID, "Vehicle", $player)) return 1;
       break;
-    case "9097316363"://Emperor Palpatine
-    case "6c5b96c7ef"://Emperor Palpatine
-      if($cardID == "1780978508" && $player == $myPlayer) { //Royal Guard
-        $isEmperorPalpatineLeader = false;
-        $character = &GetPlayerCharacter($player);
-        for($i=0; $i<count($character); $i+=CharacterPieces()) {
-          if($character[$i] == "5784497124") { //Emperor Palpatine
-            $isEmperorPalpatineLeader = true;
-            break;
-          }
-        }
-        return $isEmperorPalpatineLeader ? 0 : 1;
-      }
-      break;
     case "4511413808"://Follower of the Way
       if($index == $myIndex && $player == $myPlayer) {
         $ally = new Ally("MYALLY-" . $index, $player);
@@ -116,6 +100,41 @@ function AllyStaticHealthModifier($cardID, $index, $player, $myCardID, $myIndex,
     default: break;
   }
   return 0;
+}
+
+// Modifiers Based on Name, whether Ally or Leader
+function NameBasedHealthModifiers($cardID, $index, $player, $stackingBuff = false) {
+  $modifier = 0;
+  $foundBuff = false;
+  $char = &GetPlayerCharacter($player);
+  for($i=0; $i<count($char); $i+=CharacterPieces()) {
+    switch($char[$i])
+    {
+      case "5784497124"://Emperor Palpatine
+        if($cardID == "1780978508") {
+          $modifier += 1;//Emperor's Royal Guard
+          $foundBuff = true;
+        }
+        break;
+      default: break;
+    }
+  }
+  if($foundBuff && !$stackingBuff) return $modifier;
+
+  $allies = GetAllies($player);
+  for($i=count($allies)-AllyPieces(); $i>=0; $i-=AllyPieces()) {
+    if($foundBuff && !$stackingBuff) break;
+    switch($allies[$i]) {
+      case "9097316363"://Emperor Palpatine (Red Unit)
+      case "6c5b96c7ef"://Emperor Palpatine (Deployed Leader Unit)
+        if($cardID == "1780978508") { //Royal Guard
+          $foundBuff = true;
+          $modifier += 1;
+        }
+        break;
+    }
+  }
+  return $modifier;
 }
 
 // Health update: Leaving this for now. Not sure it is used and may be removed in a more

--- a/AllyAbilities.php
+++ b/AllyAbilities.php
@@ -786,6 +786,7 @@ function OnKillAbility($fromCombat)
       $attackerAlly->Ready();
       break;
     case "6769342445"://Jango Fett
+      WriteLog("Jango Draw");
       Draw($mainPlayer);
       break;
     default: break;
@@ -1087,12 +1088,7 @@ function AllyPlayCardAbility($cardID, $player="", $from="-", $abilityID="-", $un
       }
       break;
     case "4935319539"://Krayt Dragon
-      $damage = CardCost($cardID);
-      AddDecisionQueue("MULTIZONEINDICES", $otherPlayer, "THEIRALLY:arena=Ground");
-      AddDecisionQueue("PREPENDLASTRESULT", $otherPlayer, "THEIRCHAR-0,");
-      AddDecisionQueue("SETDQCONTEXT", $otherPlayer, "Choose a card to deal " . $damage . " damage to");
-      AddDecisionQueue("MAYCHOOSEMULTIZONE", $otherPlayer, "<-", 1);
-      AddDecisionQueue("MZOP", $otherPlayer, "DEALDAMAGE," . $damage, 1);
+      AddLayer("TRIGGER", $currentPlayer, "4935319539", $cardID, append:true);
       break;
     default: break;
   }

--- a/AllyAbilities.php
+++ b/AllyAbilities.php
@@ -786,7 +786,6 @@ function OnKillAbility($fromCombat)
       $attackerAlly->Ready();
       break;
     case "6769342445"://Jango Fett
-      WriteLog("Jango Draw");
       Draw($mainPlayer);
       break;
     default: break;

--- a/CardDictionary.php
+++ b/CardDictionary.php
@@ -1044,6 +1044,7 @@ function IsPlayable($cardID, $phase, $from, $index = -1, &$restriction = null, $
   if($from == "RESOURCES") {
     if(!PlayableFromResources($cardID, index:$index)) return false;
     if((SmuggleCost($cardID, index:$index) + SelfCostModifier($cardID, $from)) > NumResourcesAvailable($currentPlayer) && !HasAlternativeCost($cardID)) return false;
+    if(!SmuggleAdditionalCosts($cardID)) return false;
   }
   if(DefinedTypesContains($cardID, "Upgrade", $player) && SearchCount(SearchAllies($player)) == 0 && SearchCount(SearchAllies($otherPlayer)) == 0) return false;
   if($phase == "M" && $from == "HAND") return true;
@@ -1609,6 +1610,16 @@ function SmuggleCost($cardID, $player="", $index="")
     }
   }
   return $minCost;
+}
+
+function SmuggleAdditionalCosts($cardID, $player = ""): bool {
+  global $currentPlayer;
+  if($player = "") $player = $currentPlayer;
+  switch($cardID) {
+    case "4783554451"://First Light
+      return count(GetAllies($player)) > 0;
+    default: return true;
+  }
 }
 
 function PlayableFromBanish($cardID, $mod="")

--- a/CardLogic.php
+++ b/CardLogic.php
@@ -687,6 +687,26 @@ function ProcessTrigger($player, $parameter, $uniqueID, $additionalCosts, $targe
       AddDecisionQueue("MZOP", $player, "REST", 1);
       AddDecisionQueue("EXHAUSTCHARACTER", $player, FindCharacterIndex($player, "9005139831"), 1);
       break;
+    case "4935319539"://Krayt Dragon
+      $otherPlayer = ($player == 1 ? 2 : 1);
+      $damage = CardCost($target);
+      AddDecisionQueue("MULTIZONEINDICES", $otherPlayer, "THEIRALLY:arena=Ground");
+      AddDecisionQueue("PREPENDLASTRESULT", $otherPlayer, "THEIRCHAR-0,");
+      AddDecisionQueue("SETDQCONTEXT", $otherPlayer, "Choose a card to deal " . $damage . " damage to");
+      AddDecisionQueue("MAYCHOOSEMULTIZONE", $otherPlayer, "<-", 1);
+      AddDecisionQueue("MZOP", $otherPlayer, "DEALDAMAGE," . $damage, 1);
+      break;
+    case "8506660490"://Darth Vader unit
+      AddDecisionQueue("FINDINDICES", $player, "DECKTOPXINDICES,10");
+      AddDecisionQueue("FILTER", $player, "Deck-include-aspect-Villainy", 1);
+      AddDecisionQueue("FILTER", $player, "Deck-include-maxCost-3", 1);
+      AddDecisionQueue("FILTER", $player, "Deck-include-definedType-Unit", 1);
+      AddDecisionQueue("SETDQVAR", $player, "0");
+      AddDecisionQueue("PREPENDLASTRESULT", $player, "10-", 1);
+      AddDecisionQueue("MULTICHOOSEDECK", $player, "<-", 1);
+      AddDecisionQueue("MULTIREMOVEDECK", $player, "-", 1);
+      AddDecisionQueue("SPECIFICCARD", $player, "DARTHVADER", 1);
+      break;
     default: break;
   }
 }

--- a/CardLogic.php
+++ b/CardLogic.php
@@ -707,6 +707,21 @@ function ProcessTrigger($player, $parameter, $uniqueID, $additionalCosts, $targe
       AddDecisionQueue("MULTIREMOVEDECK", $player, "-", 1);
       AddDecisionQueue("SPECIFICCARD", $player, "DARTHVADER", 1);
       break;
+    case "3045538805"://Hondo Ohnaka Leader
+      AddDecisionQueue("MULTIZONEINDICES", $player, "MYALLY&THEIRALLY");
+      AddDecisionQueue("SETDQCONTEXT", $player, "Choose a unit to give an experience token", 1);
+      AddDecisionQueue("MAYCHOOSEMULTIZONE", $player, "<-", 1);
+      AddDecisionQueue("MZOP", $player, "ADDEXPERIENCE", 1);
+      AddDecisionQueue("EXHAUSTCHARACTER", $player, FindCharacterIndex($player, "3045538805"), 1);
+      break;
+    case "9334480612"://Boba Fett Green Leader
+      AddDecisionQueue("MULTIZONEINDICES", $player, "MYALLY");
+      AddDecisionQueue("SETDQCONTEXT", $player, "Choose a card to give +1 power");
+      AddDecisionQueue("MAYCHOOSEMULTIZONE", $player, "<-", 1);
+      AddDecisionQueue("MZOP", $player, "GETUNIQUEID", 1);
+      AddDecisionQueue("ADDLIMITEDCURRENTEFFECT", $player, "9334480612,HAND", 1);
+      AddDecisionQueue("EXHAUSTCHARACTER", $player, FindCharacterIndex($player, "9334480612"), 1);
+      break;
     default: break;
   }
 }

--- a/CharacterAbilities.php
+++ b/CharacterAbilities.php
@@ -148,9 +148,6 @@ function CharacterStaticHealthModifiers($cardID, $index, $player)
   for($i=0; $i<count($char); $i+=CharacterPieces()) {
     switch($char[$i])
     {
-      case "5784497124"://Emperor Palpatine
-        if($cardID == "1780978508") $modifier += 1;//Royal Guard
-        break;
       default: break;
     }
   }

--- a/Classes/Ally.php
+++ b/Classes/Ally.php
@@ -93,6 +93,7 @@ class Ally {
       }
     }
     $max += CharacterStaticHealthModifiers($this->CardID(), $this->Index(), $this->PlayerID());
+    $max += NameBasedHealthModifiers($this->CardID(), $this->Index(), $this->PlayerID());
     return $max;
   }
 

--- a/CoreLogic.php
+++ b/CoreLogic.php
@@ -309,11 +309,7 @@ function MainCharacterPlayCardAbilities($cardID, $from)
     switch($character[$i]) {
       case "3045538805"://Hondo Ohnaka
         if($from == "RESOURCES") {
-          AddDecisionQueue("MULTIZONEINDICES", $currentPlayer, "MYALLY&THEIRALLY");
-          AddDecisionQueue("SETDQCONTEXT", $currentPlayer, "Choose a unit to give an experience token", 1);
-          AddDecisionQueue("MAYCHOOSEMULTIZONE", $currentPlayer, "<-", 1);
-          AddDecisionQueue("MZOP", $currentPlayer, "ADDEXPERIENCE", 1);
-          AddDecisionQueue("EXHAUSTCHARACTER", $currentPlayer, $i, 1);
+          AddLayer("TRIGGER", $currentPlayer, "3045538805", append:true);
         }
         break;
       case "1384530409"://Cad Bane
@@ -329,12 +325,7 @@ function MainCharacterPlayCardAbilities($cardID, $from)
         break;
       case "9334480612"://Boba Fett Green Leader
         if($from != "PLAY" && DefinedTypesContains($cardID, "Unit", $currentPlayer) && HasKeyword($cardID, "Any", $currentPlayer)) {
-          AddDecisionQueue("MULTIZONEINDICES", $mainPlayer, "MYALLY");
-          AddDecisionQueue("SETDQCONTEXT", $mainPlayer, "Choose a card to give +1 power");
-          AddDecisionQueue("MAYCHOOSEMULTIZONE", $mainPlayer, "<-", 1);
-          AddDecisionQueue("MZOP", $mainPlayer, "GETUNIQUEID", 1);
-          AddDecisionQueue("ADDLIMITEDCURRENTEFFECT", $mainPlayer, "9334480612,HAND", 1);
-          AddDecisionQueue("EXHAUSTCHARACTER", $currentPlayer, $i, 1);
+          AddLayer("TRIGGER", $currentPlayer, "9334480612", append:true);
         }
         break;
       default:

--- a/CoreLogic.php
+++ b/CoreLogic.php
@@ -3283,17 +3283,9 @@ function PlayAbility($cardID, $from, $resourcesPaid, $target = "-", $additionalC
         AddDecisionQueue("SPECIFICCARD", $currentPlayer, "LTCHILDSEN", 1);
       }
       break;
-    case "8506660490"://Darth Vader
+    case "8506660490"://Darth Vader Unit
       if($from != "PLAY") {
-        AddDecisionQueue("FINDINDICES", $currentPlayer, "DECKTOPXINDICES,10");
-        AddDecisionQueue("FILTER", $currentPlayer, "Deck-include-aspect-Villainy", 1);
-        AddDecisionQueue("FILTER", $currentPlayer, "Deck-include-maxCost-3", 1);
-        AddDecisionQueue("FILTER", $currentPlayer, "Deck-include-definedType-Unit", 1);
-        AddDecisionQueue("SETDQVAR", $currentPlayer, "0");
-        AddDecisionQueue("PREPENDLASTRESULT", $currentPlayer, "10-", 1);
-        AddDecisionQueue("MULTICHOOSEDECK", $currentPlayer, "<-", 1);
-        AddDecisionQueue("MULTIREMOVEDECK", $currentPlayer, "-", 1);
-        AddDecisionQueue("SPECIFICCARD", $currentPlayer, "DARTHVADER", 1);
+        AddLayer("TRIGGER", $currentPlayer, "8506660490", append:true);
       }
       break;
     case "8615772965"://Vigilance


### PR DESCRIPTION
Bugfixes for:
- Emperor's Royal Guard being buffed twice if Deployed Leader Palp and Unit Palp are both on the board.
- First Light being playable when there is not a friendly unit to deal 4 damage to 

Trigger additions for:
- Krayt Dragon (so you can ambush before damage is dealt)
- Vader
- Boba and Hondo leaders (fixes interaction with Timely Intervention)