### PR TITLE
Bug Fixes Round 3

### DIFF
--- a/AllyAbilities.php
+++ b/AllyAbilities.php
@@ -439,7 +439,7 @@ function AllyDestroyedAbility($player, $index, $fromCombat)
         AddDecisionQueue("PREPENDLASTRESULT", $player, "MYCHAR-0,THEIRCHAR-0,");
         AddDecisionQueue("SETDQCONTEXT", $player, "Choose something to deal 1 damage to");
         AddDecisionQueue("CHOOSEMULTIZONE", $player, "<-", 1);
-        AddDecisionQueue("MZOP", $player, "DEALDAMAGE,1", 1);
+        AddDecisionQueue("MZOP", $player, "DEALDAMAGE,1," . $player, 1);
         break;
       case "9151673075"://Cobb Vanth
         AddDecisionQueue("FINDINDICES", $player, "DECKTOPXREMOVE," . 10);

--- a/AllyAbilities.php
+++ b/AllyAbilities.php
@@ -1715,10 +1715,10 @@ function JabbasRancor($player, $index=-1) {
   AddDecisionQueue("MULTIZONEINDICES", $player, "MYALLY:arena=Ground");
   if($index > -1) AddDecisionQueue("MZFILTER", $player, "index=MYALLY-" . $index);
   AddDecisionQueue("SETDQCONTEXT", $player, "Choose something to deal 3 damage to");
-  AddDecisionQueue("MAYCHOOSEMULTIZONE", $player, "<-", 1);
+  AddDecisionQueue("CHOOSEMULTIZONE", $player, "<-", 1);
   AddDecisionQueue("MZOP", $player, "DEALDAMAGE,3", 1);
   AddDecisionQueue("MULTIZONEINDICES", $player, "THEIRALLY:arena=Ground");
   AddDecisionQueue("SETDQCONTEXT", $player, "Choose something to deal 3 damage to");
-  AddDecisionQueue("MAYCHOOSEMULTIZONE", $player, "<-", 1);
+  AddDecisionQueue("CHOOSEMULTIZONE", $player, "<-", 1);
   AddDecisionQueue("MZOP", $player, "DEALDAMAGE,3", 1);
 }

--- a/AllyAbilities.php
+++ b/AllyAbilities.php
@@ -320,13 +320,13 @@ function AllyLeavesPlayAbility($player, $index)
       SearchCurrentTurnEffects("3401690666", $otherPlayer, remove:true);
       break;
     case "4002861992"://DJ (Blatant Thief)
-      $DJTurnEffect = &GetCurrentTurnEffects("4002861992", $player, remove: true);
-      if ($DJTurnEffect !== false) {
-        $cardIndex = &GetCardIndexInResources($player, $DJTurnEffect[2]);
-        if ($cardIndex >= 0) {
+      $djAlly = new Ally("MYALLY-" . $index, $player);
+      $arsenal = &GetArsenal($player);
+      for ($i = 0; $i < count($arsenal); $i += ArsenalPieces()) {
+        if ($arsenal[$i + 6] == $djAlly->UniqueID()) {
           $otherPlayer = $player == 1 ? 2 : 1;
-          $resourceCard = RemoveResource($player, $cardIndex);
-          AddResources($resourceCard, $otherPlayer, "PLAY", "DOWN");
+          $resourceCard = RemoveResource($player, $i);
+          AddResources($resourceCard, $otherPlayer, "PLAY", "DOWN", isExhausted:($arsenal[$i+4] == 1));
         }
       }
       break;

--- a/CardSetters.php
+++ b/CardSetters.php
@@ -114,7 +114,7 @@ function AddMemory($cardID, $player, $from, $facing, $counters=0)
   $arsenal[] = GetUniqueId(); //Unique ID
 }
 
-function AddResources($cardID, $player, $from, $facing, $counters=0, $isExhausted="0")
+function AddResources($cardID, $player, $from, $facing, $counters=0, $isExhausted="0", $stealSource = "-1")
 {
   $arsenal = &GetArsenal($player);
   $arsenal[] = $cardID;
@@ -123,6 +123,7 @@ function AddResources($cardID, $player, $from, $facing, $counters=0, $isExhauste
   $arsenal[] = $counters; //Counters
   $arsenal[] = $isExhausted; //Is Frozen (1 = Frozen)
   $arsenal[] = GetUniqueId(); //Unique ID
+  $arsenal[] = $stealSource;
 }
 
 function AddArsenal($cardID, $player, $from, $facing, $counters=0)

--- a/Classes/Ally.php
+++ b/Classes/Ally.php
@@ -125,10 +125,10 @@ class Ally {
   }
 
   //Returns true if the ally is destroyed
-  function DealDamage($amount, $bypassShield = false, $fromCombat = false, &$damageDealt = NULL) {
+  function DealDamage($amount, $bypassShield = false, $fromCombat = false, &$damageDealt = NULL, $enemyDamage = false) {
     if($this->index == -1 || $amount <= 0) return false;
     global $mainPlayer;
-    if(!$fromCombat && $this->CardID() == "1810342362" && !$this->LostAbilities() && $mainPlayer != $this->playerID) return;//Lurking TIE Phantom
+    if(!$fromCombat && $this->CardID() == "1810342362" && !$this->LostAbilities() && ($mainPlayer != $this->playerID || $enemyDamage)) return;//Lurking TIE Phantom
     $subcards = $this->GetSubcards();
     for($i=0; $i<count($subcards); $i+=SubcardPieces()) {
       if($subcards[$i] == "8752877738") {

--- a/CombatChain.php
+++ b/CombatChain.php
@@ -61,7 +61,7 @@ function CompletesAttackEffect($cardID) {
       if(GetAttackTarget() == "NA") {//This means the target was defeated
         $discard = &GetDiscard($defPlayer);
         $defeatedCard = RemoveDiscard($defPlayer, count($discard)-DiscardPieces());
-        AddResources($defeatedCard, $mainPlayer, "PLAY", "DOWN");
+        AddResources($defeatedCard, $mainPlayer, "PLAY", "DOWN", isExhausted:true);
       }
       break;
     default: break;

--- a/Constants.php
+++ b/Constants.php
@@ -107,9 +107,10 @@ function CharacterEffectPieces()
 //3 - Counters
 //4 - Exhausted: 0 = no, 1 = yes
 //5 - Unique ID
+//6 - Steal Source (i.e. DJ or Arquitens)
 function ArsenalPieces()
 {
-  return 6;
+  return 7;
 }
 function MemoryPieces() { return ArsenalPieces(); }
 function ResourcePieces() { return ArsenalPieces(); }

--- a/CoreLogic.php
+++ b/CoreLogic.php
@@ -4256,11 +4256,11 @@ function PlayAbility($cardID, $from, $resourcesPaid, $target = "-", $additionalC
       break;
     case "4002861992"://DJ (Blatant Thief)
       if($from == "RESOURCES") {
+        $djAlly = new Ally("MYALLY-" . LastAllyIndex($currentPlayer), $currentPlayer);
         $otherPlayer = $currentPlayer == 1 ? 2 : 1;
         $theirResources = &GetResourceCards($otherPlayer);
         $resourceCard = RemoveResource($otherPlayer, count($theirResources) - ResourcePieces());
-        AddResources($resourceCard, $currentPlayer, "PLAY", "DOWN");
-        AddCurrentTurnEffect($cardID, $currentPlayer, "", $resourceCard);
+        AddResources($resourceCard, $currentPlayer, "PLAY", "DOWN", stealSource:$djAlly->UniqueID());
       }
       break;
     case "7718080954"://Frozen in Carbonite

--- a/CoreLogic.php
+++ b/CoreLogic.php
@@ -2753,11 +2753,11 @@ function PlayAbility($cardID, $from, $resourcesPaid, $target = "-", $additionalC
       if($from != "PLAY") {
         AddDecisionQueue("MULTIZONEINDICES", $currentPlayer, "MYALLY:arena=Ground");
         AddDecisionQueue("SETDQCONTEXT", $currentPlayer, "Choose a unit to deal 2 damage to");
-        AddDecisionQueue("MAYCHOOSEMULTIZONE", $currentPlayer, "<-", 1);
+        AddDecisionQueue("CHOOSEMULTIZONE", $currentPlayer, "<-", 1);
         AddDecisionQueue("MZOP", $currentPlayer, "DEALDAMAGE,2", 1);
         AddDecisionQueue("MULTIZONEINDICES", $currentPlayer, "THEIRALLY:arena=Ground");
         AddDecisionQueue("SETDQCONTEXT", $currentPlayer, "Choose a unit to deal 2 damage to");
-        AddDecisionQueue("MAYCHOOSEMULTIZONE", $currentPlayer, "<-", 1);
+        AddDecisionQueue("CHOOSEMULTIZONE", $currentPlayer, "<-", 1);
         AddDecisionQueue("MZOP", $currentPlayer, "DEALDAMAGE,2", 1);
       }
       break;

--- a/DecisionQueue/DecisionQueueEffects.php
+++ b/DecisionQueue/DecisionQueueEffects.php
@@ -425,8 +425,8 @@ function SpecificCardLogic($player, $card, $lastResult)
     case "L337":
       $target = $lastResult;
       if($target == "PASS") {
-        $allies = &GetAllies($player);
-        $ally = new Ally("MYALLY-" . count($allies) - AllyPieces(), $player);
+        $ally = new Ally("MYALLY-" . SearchAlliesForCard($player, "9552605383"), $player);
+        if($ally)
         $ally->Attach("8752877738");//Shield Token
       } else {
         $owner = MZPlayerID($player, $target);

--- a/GameLogic.php
+++ b/GameLogic.php
@@ -372,7 +372,7 @@ function DecisionQueueStaticEffect($phase, $player, $parameter, $lastResult)
             $isAttackTarget = GetAttackTarget() == $lastResult;
             $isAttacker = AttackerMZID($player) == $lastResult;
             $ally = new Ally($lastResult);
-            $destroyed = $ally->DealDamage($parameterArr[1]);
+            $destroyed = $ally->DealDamage($parameterArr[1], enemyDamage:(count($parameterArr) > 2 && $parameterArr[2] != $targetPlayer));
             if($destroyed) {
               if($isAttackTarget || $isAttacker) CloseCombatChain();
               return "";


### PR DESCRIPTION
Bugfixes for:
- Ensure DJ works properly in all cases by storing the unique ID of the card that stole the resource on the Resource itself
- Ensure L337 can only give shields to L337 (This doesn't 100% fix the edge case - if someone plays a L337 while having one on the board, and choosing to sacrifice the new L337, you can give the shield to the L337 on the board already. This has proven very tricky to plan around, but this improvement fixes most issues.)
- Jabba's Rancor and Death Trooper are no longer optional
- Arquitens Assault Cruiser no longer brings resource into play readied
- Lurking TIE Phantom should no longer die to any enemy damage and should not be immune to friendly damage