### PR TITLE
Fix for trigger order flipping

### DIFF
--- a/AllyAbilities.php
+++ b/AllyAbilities.php
@@ -911,12 +911,12 @@ function AddAllyPlayAbilityLayers($cardID, $from, $uniqueID = "-") {
   global $currentPlayer;
   $allies = &GetAllies($currentPlayer);
   for($i=0; $i<count($allies); $i+=AllyPieces()) {
-    if(AllyHasPlayCardAbility($cardID, $uniqueID, $from, $allies[$i], $currentPlayer, $i)) AddLayer("TRIGGER", $currentPlayer, "AFTERPLAYABILITY", $cardID, $from, $allies[$i] . "," . $allies[$i+5], append:true);
+    if(AllyHasPlayCardAbility($cardID, $uniqueID, $from, $allies[$i], $currentPlayer, $i)) AddLayer("TRIGGER", $currentPlayer, "AFTERPLAYABILITY", $cardID, $from, $allies[$i] . "," . $allies[$i+5], ['append' => true]);
   }
   $otherPlayer = $currentPlayer == 1 ? 2 : 1;
   $theirAllies = &GetAllies($otherPlayer);
   for($i=0; $i<count($theirAllies); $i+=AllyPieces()) {
-    if(AllyHasPlayCardAbility($cardID, $uniqueID, $from, $theirAllies[$i], $otherPlayer, $i)) AddLayer("TRIGGER", $currentPlayer, "AFTERPLAYABILITY", $cardID, $from, $theirAllies[$i] . "," . $allies[$i+5], append:true);
+    if(AllyHasPlayCardAbility($cardID, $uniqueID, $from, $theirAllies[$i], $otherPlayer, $i)) AddLayer("TRIGGER", $currentPlayer, "AFTERPLAYABILITY", $cardID, $from, $theirAllies[$i] . "," . $allies[$i+5], ['append' => true]);
   }
 }
 
@@ -1023,13 +1023,13 @@ function AllyPlayCardAbility($cardID, $player="", $from="-", $abilityID="-", $un
       if($cadIndex != "") {
         $cadbane = new Ally("MYALLY-" . $cadIndex, $player);
         if($from != 'PLAY' && $cadbane->NumUses() > 0 && TraitContains($cardID, "Underworld", $currentPlayer)) {
-          AddLayer("TRIGGER", $currentPlayer, "724979d608", append:true);
+          AddLayer("TRIGGER", $currentPlayer, "724979d608", ['append' => true]);
         }
       }
       break;
     case "4088c46c4d"://The Mandalorian
       if(DefinedTypesContains($cardID, "Upgrade", $player)) {
-        AddLayer("TRIGGER", $currentPlayer, "4088c46c4d", append:true);
+        AddLayer("TRIGGER", $currentPlayer, "4088c46c4d", ['append' => true]);
       }
       break;
     case "3952758746"://Toro Calican
@@ -1037,7 +1037,7 @@ function AllyPlayCardAbility($cardID, $player="", $from="-", $abilityID="-", $un
       if($toroIndex != "") {
         $toroCalican = new Ally("MYALLY-" . $toroIndex, $player);
         if(TraitContains($cardID, "Bounty Hunter", $currentPlayer) && $toroCalican->NumUses() > 0){
-          AddLayer("TRIGGER", $currentPlayer, "3952758746", append:true);
+          AddLayer("TRIGGER", $currentPlayer, "3952758746", ['append' => true]);
         }
       }
       break;
@@ -1064,7 +1064,7 @@ function AllyPlayCardAbility($cardID, $player="", $from="-", $abilityID="-", $un
       }
       break;
     case "4935319539"://Krayt Dragon
-      AddLayer("TRIGGER", $currentPlayer, "4935319539", $cardID, append:true);
+      AddLayer("TRIGGER", $currentPlayer, "4935319539", $cardID, ['append' => true]);
       break;
     default: break;
   }

--- a/CardLogic.php
+++ b/CardLogic.php
@@ -564,7 +564,7 @@ function ProcessAfterCombatLayer() {
   $combatChainState[$CCS_AfterLinkLayers] = "NA";
   for($i = 0; $i < count($layers); $i++) {
     $layer = explode("~", $layers[$i]);
-    AddLayer($layer[0], $layer[1], $layer[2], $layer[3], $layer[4], $layer[5], append:true);
+    AddLayer($layer[0], $layer[1], $layer[2], $layer[3], $layer[4], $layer[5], ['append' => true]);
   }
 }
 

--- a/CoreLogic.php
+++ b/CoreLogic.php
@@ -309,23 +309,23 @@ function MainCharacterPlayCardAbilities($cardID, $from)
     switch($character[$i]) {
       case "3045538805"://Hondo Ohnaka
         if($from == "RESOURCES") {
-          AddLayer("TRIGGER", $currentPlayer, "3045538805", append:true);
+          AddLayer("TRIGGER", $currentPlayer, "3045538805", ['append' => true]);
         }
         break;
       case "1384530409"://Cad Bane
         if($from != 'PLAY' && $from != 'EQUIP' && TraitContains($cardID, "Underworld", $currentPlayer)) {
           // Note - this is a bit of a hack by sending the index in as the unique ID
-          AddLayer("TRIGGER", $currentPlayer, "1384530409", append:true);
+          AddLayer("TRIGGER", $currentPlayer, "1384530409", ['append' => true]);
         }
         break;
       case "9005139831"://The Mandalorian
         if(DefinedTypesContains($cardID, "Upgrade", $currentPlayer)) {
-          AddLayer("TRIGGER", $currentPlayer, "9005139831", append:true);
+          AddLayer("TRIGGER", $currentPlayer, "9005139831", ['append' => true]);
         }
         break;
       case "9334480612"://Boba Fett Green Leader
         if($from != "PLAY" && DefinedTypesContains($cardID, "Unit", $currentPlayer) && HasKeyword($cardID, "Any", $currentPlayer)) {
-          AddLayer("TRIGGER", $currentPlayer, "9334480612", append:true);
+          AddLayer("TRIGGER", $currentPlayer, "9334480612", ['append' => true]);
         }
         break;
       default:
@@ -3251,7 +3251,7 @@ function PlayAbility($cardID, $from, $resourcesPaid, $target = "-", $additionalC
       break;
     case "8506660490"://Darth Vader Unit
       if($from != "PLAY") {
-        AddLayer("TRIGGER", $currentPlayer, "8506660490", append:true);
+        AddLayer("TRIGGER", $currentPlayer, "8506660490", ['append' => true]);
       }
       break;
     case "8615772965"://Vigilance

--- a/Libraries/NetworkingLibraries.php
+++ b/Libraries/NetworkingLibraries.php
@@ -1800,7 +1800,7 @@ function PlayCardEffect($cardID, $from, $resourcesPaid, $target = "-", $addition
         }
         if($layerName == "ATTACKABILITY") { if(HasAttackAbility($cardID)) PlayAbility($cardID, "PLAY", "0"); }
         //TODO: Fix this Relentless and first light and The Mandalorian hack
-        else if($from == "PLAY" || $from == "EQUIP" || HasWhenPlayed($cardID) || $cardID == "3401690666" || $cardID == "4783554451" || $cardID == "4088c46c4d" || DefinedTypesContains($cardID, "Event", $currentPlayer) || DefinedTypesContains($cardID, "Upgrade", $currentPlayer)) AddLayer($layerName, $currentPlayer, $cardID, $from . "!" . $resourcesPaid . "!" . $target . "!" . $additionalCosts . "!" . $abilityIndex . "!" . $playIndex, "-", $uniqueID, append:true);
+        else if($from == "PLAY" || $from == "EQUIP" || HasWhenPlayed($cardID) || $cardID == "3401690666" || $cardID == "4783554451" || $cardID == "4088c46c4d" || DefinedTypesContains($cardID, "Event", $currentPlayer) || DefinedTypesContains($cardID, "Upgrade", $currentPlayer)) AddLayer($layerName, $currentPlayer, $cardID, $from . "!" . $resourcesPaid . "!" . $target . "!" . $additionalCosts . "!" . $abilityIndex . "!" . $playIndex, "-", $uniqueID, ['append' => true]);
         else if($from != "PLAY" && $from != "EQUIP") {
           AddAllyPlayAbilityLayers($cardID, $from, $uniqueID);
         }
@@ -1808,10 +1808,10 @@ function PlayCardEffect($cardID, $from, $resourcesPaid, $target = "-", $addition
     }
     if($from != "PLAY") {
       if(HasShielded($cardID, $currentPlayer, $index)) {
-        AddLayer("TRIGGER", $currentPlayer, "SHIELDED", "-", "-", $uniqueID, append:true);
+        AddLayer("TRIGGER", $currentPlayer, "SHIELDED", "-", "-", $uniqueID, ['append' => true]);
       }
       if(HasAmbush($cardID, $currentPlayer, $index, $from)) {
-        AddLayer("TRIGGER", $currentPlayer, "AMBUSH", "-", "-", $uniqueID, append:true);
+        AddLayer("TRIGGER", $currentPlayer, "AMBUSH", "-", "-", $uniqueID, ['append' => true]);
       }
     }
     if (!$openedChain) ResolveGoAgain($cardID, $currentPlayer, $from);


### PR DESCRIPTION
The 'append:true' syntax is not native to PHP. It seems to follow JavaScript object notation. In PHP, associative arrays use the => syntax for key-value pairs. I have updated the code to use the correct syntax.

Making this change fixes the issue with the trigger pop-up 'flipping' the order of triggers when 'Pass' is clicked, requiring users to fix the order and click 'Pass' for a second time. See Death Vader unit card as the most common example.