### PR TITLE
fix last ally index (for multiple play)

### DIFF
--- a/CardLogic.php
+++ b/CardLogic.php
@@ -453,14 +453,12 @@ function ContinueDecisionQueue($lastResult = "")
               $additionalCosts = count($subparamArr) > 3 ? $subparamArr[3] : "-";
               $abilityIndex = count($subparamArr) > 4 ? $subparamArr[4] : -1;
               $playIndex = count($subparamArr) > 5 ? $subparamArr[5] : -1;
-                SetClassState($player, $CS_AbilityIndex, $abilityIndex);
-                SetClassState($player, $CS_PlayIndex, $playIndex);
-                $playText = PlayAbility($cardID, $from, $resourcesPaid, $target, $additionalCosts, $oppCardActive);
-                if($from != "PLAY") WriteLog("Resolving play ability of " . CardLink($cardID, $cardID) . ($playText != "" ? ": " : ".") . $playText);
-                if($from == "EQUIP") {
-                  EquipPayAdditionalCosts(FindCharacterIndex($player, $cardID), "EQUIP");
-                }
-                ProcessDecisionQueue();
+              SetClassState($player, $CS_AbilityIndex, $abilityIndex);
+              SetClassState($player, $CS_PlayIndex, $playIndex);
+              $playText = PlayAbility($cardID, $from, $resourcesPaid, $target, $additionalCosts, $oppCardActive, uniqueId: $uniqueID);
+              if($from != "PLAY") WriteLog("Resolving play ability of " . CardLink($cardID, $cardID) . ($playText != "" ? ": " : ".") . $playText);
+              if($from == "EQUIP") EquipPayAdditionalCosts(FindCharacterIndex($player, $cardID), "EQUIP");
+              ProcessDecisionQueue();
             }
           }
         }

--- a/CoreLogic.php
+++ b/CoreLogic.php
@@ -2056,7 +2056,7 @@ function IsClassBonusActive($player, $class)
   return false;
 }
 
-function PlayAbility($cardID, $from, $resourcesPaid, $target = "-", $additionalCosts = "-", $theirCard = false)
+function PlayAbility($cardID, $from, $resourcesPaid, $target = "-", $additionalCosts = "-", $theirCard = false, $uniqueId = "")
 {
   global $currentPlayer, $layers, $CS_PlayIndex, $CS_OppIndex, $initiativePlayer, $CCS_CantAttackBase;
   $index = GetClassState($currentPlayer, $CS_PlayIndex);
@@ -2081,7 +2081,12 @@ function PlayAbility($cardID, $from, $resourcesPaid, $target = "-", $additionalC
     $target = count($targetArr) > 1 ? $targetArr[0] . "-" . $targetArr[1] : "-";
   }
   if($from != "PLAY" && IsAlly($cardID, $currentPlayer)) {
-    $playAlly = new Ally("MYALLY-" . LastAllyIndex($currentPlayer));
+    //LastAllyIndex does not work well when you play multiple unit on same times (Vader, U-Wing, Endless Legion ...)
+    if($uniqueId != "") {
+      $playAlly = new Ally("MYALLY-" . SearchAlliesForUniqueID($additionalCosts, $currentPlayer));
+    } else {
+      $playAlly = new Ally("MYALLY-" . LastAllyIndex($currentPlayer));
+    }
   }
   if($from != "PLAY" && $from != "EQUIP" && $from != "CHAR") {
     AddAllyPlayAbilityLayers($cardID, $from, $playAlly ? $playAlly->UniqueID() : "-");
@@ -2099,7 +2104,7 @@ function PlayAbility($cardID, $from, $resourcesPaid, $target = "-", $additionalC
         $allies = &GetAllies($currentPlayer);
         AddLayer("TRIGGER", $currentPlayer, "SHIELDED", "-", "-", $allies[$playIndex + 5]);
       }
-      PlayAbility(LeaderUnit($cardID), "CHAR", 0, "-", "-");
+      PlayAbility(LeaderUnit($cardID), "CHAR", 0, "-", "-", false, $uniqueId);
       //On Deploy ability
       switch($cardID) {
         case "5784497124"://Emperor Palpatine
@@ -2615,9 +2620,8 @@ function PlayAbility($cardID, $from, $resourcesPaid, $target = "-", $additionalC
     case "3018017739"://Vanguard Ace
       global $CS_NumCardsPlayed;
       if($from != "PLAY") {
-        $ally = new Ally("MYALLY-" . LastAllyIndex($currentPlayer));
         for($i=0; $i<(GetClassState($currentPlayer, $CS_NumCardsPlayed)-1); ++$i) {
-          $ally->Attach("2007868442");//Experience token
+          $playAlly->Attach("2007868442");//Experience token
         }
       }
       break;
@@ -2886,15 +2890,14 @@ function PlayAbility($cardID, $from, $resourcesPaid, $target = "-", $additionalC
       break;
     case "3896582249"://Redemption
       if($from != "PLAY") {
-        $ally = new Ally("MYALLY-" . LastAllyIndex($currentPlayer));
         for($i=0; $i<8; ++$i) {
           AddDecisionQueue("MULTIZONEINDICES", $currentPlayer, "MYALLY&THEIRALLY", $i == 0 ? 0 : 1);
           AddDecisionQueue("PREPENDLASTRESULT", $currentPlayer, "MYCHAR-0,THEIRCHAR-0,", $i == 0 ? 0 : 1);
-          AddDecisionQueue("MZFILTER", $currentPlayer, "index=MYALLY-" . $ally->Index());
+          AddDecisionQueue("MZFILTER", $currentPlayer, "index=MYALLY-" . $playAlly->Index());
           AddDecisionQueue("SETDQCONTEXT", $currentPlayer, "Choose a card to restore 1 (Remaining: " . (8-$i) . ")", $i == 0 ? 0 : 1);
           AddDecisionQueue("MAYCHOOSEMULTIZONE", $currentPlayer, "<-", 1);
           AddDecisionQueue("MZOP", $currentPlayer, "RESTORE,1", 1);
-          AddDecisionQueue("UNIQUETOMZ", $currentPlayer, $ally->UniqueID(), 1);
+          AddDecisionQueue("UNIQUETOMZ", $currentPlayer, $playAlly->UniqueID(), 1);
           AddDecisionQueue("MZOP", $currentPlayer, "DEALDAMAGE,1", 1);
         }
       }
@@ -4017,7 +4020,7 @@ function PlayAbility($cardID, $from, $resourcesPaid, $target = "-", $additionalC
       Draw($currentPlayer);
       break;
     case "9270539174"://Wild Rancor
-      DamageAllAllies(2, "9270539174", arena:"Ground", except:"MYALLY-".LastAllyIndex($currentPlayer));
+      DamageAllAllies(2, "9270539174", arena: "Ground", except: "MYALLY-" . $playAlly->Index());
       break;
     case "2744523125"://Salacious Crumb
       $abilityName = GetResolvedAbilityName($cardID, $from);

--- a/DecisionQueue/DecisionQueueEffects.php
+++ b/DecisionQueue/DecisionQueueEffects.php
@@ -281,7 +281,7 @@ function SpecificCardLogic($player, $card, $lastResult)
       $searchLeftovers = explode(",", $deck->Top(true, 10 - count($cardArr)));
       shuffle($searchLeftovers);
       for($i=0; $i<count($searchLeftovers); ++$i) {
-        AddBottomDeck($searchLeftovers[$i], $player, $parameter);
+        AddBottomDeck($searchLeftovers[$i], $player, "");
       }
       break;
     case "DARTHVADER":

--- a/Libraries/NetworkingLibraries.php
+++ b/Libraries/NetworkingLibraries.php
@@ -1237,9 +1237,8 @@ function PlayCard($cardID, $from, $dynCostResolved = -1, $index = -1, $uniqueID 
   global $playerID, $turn, $currentPlayer, $actionPoints, $layers;
   global $layerPriority, $lastPlayed;
   global $decisionQueue, $CS_PlayIndex, $CS_OppIndex, $CS_OppCardActive, $CS_PlayUniqueID, $CS_LayerPlayIndex, $CS_LastDynCost, $CS_NumCardsPlayed;
-  global $mainPlayer, $CS_DynCostResolved, $CS_NumVillainyPlayed, $CS_NumEventsPlayed, $CS_NumClonesPlayed;
+  global $CS_DynCostResolved, $CS_NumVillainyPlayed, $CS_NumEventsPlayed, $CS_NumClonesPlayed;
   $resources = &GetResources($currentPlayer);
-  $pitch = &GetPitch($currentPlayer);
   $dynCostResolved = intval($dynCostResolved);
   $layerPriority[0] = ShouldHoldPriority(1);
   $layerPriority[1] = ShouldHoldPriority(2);
@@ -1313,13 +1312,9 @@ function PlayCard($cardID, $from, $dynCostResolved = -1, $index = -1, $uniqueID 
       if($from != "PLAY" && ($turn[0] != "B" || (count($layers) > 0 && $layers[0] != ""))) GetLayerTarget($cardID);
       //Right now only units in play can attack
       if (!$oppCardActive) {
-        if ($from == "PLAY")
-          AddDecisionQueue("GETTARGETOFATTACK", $currentPlayer, $cardID . "," . $from);
-
-        if ($dynCost == "")
-          AddDecisionQueue("PASSPARAMETER", $currentPlayer, "0");
-        else
-          AddDecisionQueue("GETCLASSSTATE", $currentPlayer, $CS_LastDynCost);
+        if($from == "PLAY") AddDecisionQueue("GETTARGETOFATTACK", $currentPlayer, $cardID . "," . $from);
+        if($dynCost == "") AddDecisionQueue("PASSPARAMETER", $currentPlayer, "0");
+        else AddDecisionQueue("GETCLASSSTATE", $currentPlayer, $CS_LastDynCost);
         AddDecisionQueue("RESUMEPAYING", $currentPlayer, $cardID . "-" . $from . "-" . $index);
       }
       $decisionQueue = array_merge($decisionQueue, $dqCopy);


### PR DESCRIPTION
With U-Wing, Darth Vader or Endless Legion, if you play multiple unit, LastAllyIndex is incorrect while you resolve unit's ability. Fix it with uniqueID.

Involved units : 
- Redemption
- Vanguard Ace
- Guerrilla Attack Pod
- The Ghost
- Imperial Interceptor
- Count Dooku
- TIE Advanced
- Wing Leader
- Fett's Firespray
- Mandalorian Warrior
- Outland TIE Vanguard
- Krrsantan
- Discerning Veteran
- Xanadu Blood
- Wild Rancor
- Chewbaca Pikesbane
- Trandoshan Hunters
- Jabba's Rancor