### PR TITLE
Fixed more bugs

### DIFF
--- a/AllyAbilities.php
+++ b/AllyAbilities.php
@@ -62,6 +62,7 @@ function AllyHasStaticHealthModifier($cardID)
     case "4339330745"://Wedge Antilles
     case "4511413808"://Follower of the Way
     case "3731235174"://Supreme Leader Snoke
+    case "8418001763"://Huyang
     case "6097248635"://4-LOM
     case "1690726274"://Zuckuss
     case "2260777958"://41st Elite Corps
@@ -117,6 +118,12 @@ function AllyStaticHealthModifier($cardID, $index, $player, $myCardID, $myIndex,
       break;
     case "3731235174"://Supreme Leader Snoke
       return $player != $myPlayer && !IsLeader($cardID, $player) ? -2 : 0;
+    case "8418001763"://Huyang
+      if ($player == $myPlayer) {
+        $ally = new Ally("MYALLY-" . $index, $player);
+        return SearchLimitedCurrentTurnEffects($myCardID, $player) == $ally->UniqueID() ? 2 : 0;
+      }
+      return 0;
     case "6097248635"://4-LOM
       return ($player == $myPlayer && CardTitle($cardID) == "Zuckuss") ? 1 : 0;
     case "1690726274"://Zuckuss
@@ -385,6 +392,9 @@ function AllyLeavesPlayAbility($player, $index)
     case "3401690666"://Relentless
       $otherPlayer = ($player == 1 ? 2 : 1);
       SearchCurrentTurnEffects("3401690666", $otherPlayer, remove:true);
+      break;
+    case "8418001763"://Huyang
+      SearchCurrentTurnEffects("8418001763", $player, remove:true);
       break;
     case "4002861992"://DJ (Blatant Thief)
       $djAlly = new Ally("MYALLY-" . $index, $player);

--- a/CardDictionary.php
+++ b/CardDictionary.php
@@ -897,8 +897,8 @@ function GetAbilityTypes($cardID, $index = -1, $from="-")
     case "1686059165"://Wat Tambor
       $abilityTypes = "A";
       break;
-    case "0026166404"://Emperor Palpatine
-    case "ad86d54e97"://Darth Sidious
+    case "0026166404"://Chancellor Palpatine Leader
+    case "ad86d54e97"://Darth Sidious Leader
       $abilityTypes = "A";
       break;
     case "7734824762"://Captain Rex
@@ -1112,8 +1112,8 @@ function GetAbilityNames($cardID, $index = -1, $validate=false)
     case "7734824762"://Captain Rex
       $abilityNames = "Clone";
       break;
-    case "0026166404"://Emperor Palpatine
-    case "ad86d54e97"://Darth Sidious
+    case "0026166404"://Chancellor Palpatine Leader
+    case "ad86d54e97"://Darth Sidious Leader
       $abilityNames = "Activate";
       break;
     case "4628885755"://Mace Windu
@@ -1249,7 +1249,7 @@ function GetAbilityNames($cardID, $index = -1, $validate=false)
     $char = &GetPlayerCharacter($currentPlayer);
     if($char[CharacterPieces() + 1] == 1) $abilityNames = "";
     if($char[CharacterPieces() + 2] == 0) {
-      //Emperor Palpatine + Darth Sidious
+      //Chancellor Palpatine Leader + Darth Sidious Leader
       if($char[CharacterPieces()] != "0026166404" && $char[CharacterPieces()] != "ad86d54e97") {
         if($abilityNames != "") $abilityNames .= ",";
         $abilityNames .= "Deploy";

--- a/CardGetters.php
+++ b/CardGetters.php
@@ -315,6 +315,12 @@ function &GetAllies($player)
   else return $p2Allies;
 }
 
+function &GetTheirAllies($player)
+{
+  global $p1Allies, $p2Allies;
+  return $player == 1 ? $p2Allies : $p1Allies;
+}
+
 function &GetPermanents($player)
 {
   global $p1Permanents, $p2Permanents;

--- a/Classes/Ally.php
+++ b/Classes/Ally.php
@@ -282,7 +282,7 @@ class Ally {
     for($i=0; $i<count($currentTurnEffects); $i+=CurrentTurnEffectPieces()) {
       if($currentTurnEffects[$i+1] != $this->playerID) continue;
       if($currentTurnEffects[$i+2] != -1 && $currentTurnEffects[$i+2] != $this->UniqueID()) continue;
-      $power += EffectAttackModifier($currentTurnEffects[$i], $this->PlayerID());
+      $power += EffectAttackModifier($currentTurnEffects[$i], $this->PlayerID(), $this->CardID());
     }
     if($power < 0) $power = 0;
     return $power;

--- a/Classes/Ally.php
+++ b/Classes/Ally.php
@@ -282,7 +282,7 @@ class Ally {
     for($i=0; $i<count($currentTurnEffects); $i+=CurrentTurnEffectPieces()) {
       if($currentTurnEffects[$i+1] != $this->playerID) continue;
       if($currentTurnEffects[$i+2] != -1 && $currentTurnEffects[$i+2] != $this->UniqueID()) continue;
-      $power += EffectAttackModifier($currentTurnEffects[$i], $this->PlayerID(), $this->CardID());
+      $power += EffectAttackModifier($currentTurnEffects[$i], $this->PlayerID());
     }
     if($power < 0) $power = 0;
     return $power;

--- a/CoreLogic.php
+++ b/CoreLogic.php
@@ -3061,28 +3061,6 @@ function PlayAbility($cardID, $from, $resourcesPaid, $target = "-", $additionalC
       AddDecisionQueue("MZOP", $currentPlayer, "REDUCEHEALTH,4", 1);
       break;
     case "5013214638"://Equalize
-      AddDecisionQueue("MULTIZONEINDICES", $currentPlayer, "THEIRALLY");
-      AddDecisionQueue("SETDQCONTEXT", $currentPlayer, "Choose a card to exhaust");
-      AddDecisionQueue("MAYCHOOSEMULTIZONE", $currentPlayer, "<-", 1);
-      AddDecisionQueue("MZOP", $currentPlayer, "REST", 1);
-      AddDecisionQueue("MZOP", $currentPlayer, "GETUNIQUEID", 1);
-      AddDecisionQueue("ADDLIMITEDCURRENTEFFECT", $otherPlayer, "8800836530", 1);
-      AddDecisionQueue("ADDLIMITEDNEXTTURNEFFECT", $otherPlayer, "8800836530", 1);
-
-
-      AddDecisionQueue("PASSPARAMETER", $currentPlayer, "-", 1);
-      AddDecisionQueue("SETDQVAR", $currentPlayer, 0, 1);
-      for($i=3; $i>0; --$i) {
-        AddDecisionQueue("MULTIZONEINDICES", $currentPlayer, "MYALLY");
-        AddDecisionQueue("MZFILTER", $currentPlayer, "dqVar=0");
-        AddDecisionQueue("SETDQCONTEXT", $currentPlayer, "Choose a unit to give +" . $i . "/+" . $i, 1);
-        AddDecisionQueue("MAYCHOOSEMULTIZONE", $currentPlayer, "<-", 1);
-        AddDecisionQueue("APPENDDQVAR", $currentPlayer, 0, 1);
-        AddDecisionQueue("MZOP", $currentPlayer, "ADDHEALTH," . $i, 1);
-        AddDecisionQueue("MZOP", $currentPlayer, "GETUNIQUEID", 1);
-        AddDecisionQueue("ADDLIMITEDCURRENTEFFECT", $currentPlayer, "1939951561_" . $i . ",PLAY", 1);
-      }
-
       AddDecisionQueue("PASSPARAMETER", $currentPlayer, "-", 1);
       AddDecisionQueue("SETDQVAR", $currentPlayer, 0, 1);
       for($i=0; $i<2; ++$i) {

--- a/CoreLogic.php
+++ b/CoreLogic.php
@@ -1866,6 +1866,13 @@ function PlayerAspects($player)
     for($j=0; $j<count($cardAspects); ++$j) {
       ++$aspects[$cardAspects[$j]];
     }
+
+    // Special case
+    if ($char[$i] == '0026166404') { //Chancellor Palpatine Leader
+      $aspects["Villainy"] = 0;
+    } else if ($char[$i] == 'ad86d54e97') { //Darth Sidious Leader
+      $aspects["Heroism"] = 0;
+    }
   }
   $leaderIndex = SearchAllies($player, definedType:"Leader");
   if($leaderIndex != "") {
@@ -4798,12 +4805,12 @@ function PlayAbility($cardID, $from, $resourcesPaid, $target = "-", $additionalC
       AddDecisionQueue("MAYCHOOSEMULTIZONE", $currentPlayer, "<-", 1);
       AddDecisionQueue("MZOP", $currentPlayer, "DEALDAMAGE,1", 1);
       break;
-    case "0026166404"://Emperor Palpatine
+    case "0026166404"://Chancellor Palpatine Leader
       AddDecisionQueue("YESNO", $currentPlayer, "if a Heroism unit died this turn");
       AddDecisionQueue("NOPASS", $currentPlayer, "-");
       AddDecisionQueue("SPECIFICCARD", $currentPlayer, "TWI_PALPATINE_HERO", 1);
       break;
-    case "ad86d54e97"://Darth Sidious
+    case "ad86d54e97"://Darth Sidious Leader
       AddDecisionQueue("YESNO", $currentPlayer, "if you played a Villainy unit this turn");
       AddDecisionQueue("NOPASS", $currentPlayer, "-");
       AddDecisionQueue("SPECIFICCARD", $currentPlayer, "TWI_DARTHSIDIOUS_HERO", 1);

--- a/CoreLogic.php
+++ b/CoreLogic.php
@@ -2185,7 +2185,7 @@ function PlayAbility($cardID, $from, $resourcesPaid, $target = "-", $additionalC
         case "7734824762"://Captain Rex
           PlayAlly("3941784506", $currentPlayer);//Clone Trooper
           break;
-        case "2847868671"://Yoda
+        case "2847868671"://Yoda Leader
         $deck = &GetDeck($currentPlayer);
         if(count($deck) > 0) {
           AddDecisionQueue("SETDQCONTEXT", $currentPlayer, "Choose if you want to discard a card to Yoda");
@@ -2196,6 +2196,7 @@ function PlayAbility($cardID, $from, $resourcesPaid, $target = "-", $additionalC
           AddDecisionQueue("MZOP", $currentPlayer, "GETCARDCOST", 1);
           AddDecisionQueue("SETDQVAR", $currentPlayer, "0", 1);
           AddDecisionQueue("MULTIZONEINDICES", $currentPlayer, "THEIRALLY:maxCost={0}", 1);
+          AddDecisionQueue("MZFILTER", $currentPlayer, "definedType=Leader");
           AddDecisionQueue("SETDQCONTEXT", $currentPlayer, "Choose a unit to destroy");
           AddDecisionQueue("MAYCHOOSEMULTIZONE", $currentPlayer, "<-", 1);
           AddDecisionQueue("MZOP", $currentPlayer, "DESTROY", 1);
@@ -3060,6 +3061,28 @@ function PlayAbility($cardID, $from, $resourcesPaid, $target = "-", $additionalC
       AddDecisionQueue("MZOP", $currentPlayer, "REDUCEHEALTH,4", 1);
       break;
     case "5013214638"://Equalize
+      AddDecisionQueue("MULTIZONEINDICES", $currentPlayer, "THEIRALLY");
+      AddDecisionQueue("SETDQCONTEXT", $currentPlayer, "Choose a card to exhaust");
+      AddDecisionQueue("MAYCHOOSEMULTIZONE", $currentPlayer, "<-", 1);
+      AddDecisionQueue("MZOP", $currentPlayer, "REST", 1);
+      AddDecisionQueue("MZOP", $currentPlayer, "GETUNIQUEID", 1);
+      AddDecisionQueue("ADDLIMITEDCURRENTEFFECT", $otherPlayer, "8800836530", 1);
+      AddDecisionQueue("ADDLIMITEDNEXTTURNEFFECT", $otherPlayer, "8800836530", 1);
+
+
+      AddDecisionQueue("PASSPARAMETER", $currentPlayer, "-", 1);
+      AddDecisionQueue("SETDQVAR", $currentPlayer, 0, 1);
+      for($i=3; $i>0; --$i) {
+        AddDecisionQueue("MULTIZONEINDICES", $currentPlayer, "MYALLY");
+        AddDecisionQueue("MZFILTER", $currentPlayer, "dqVar=0");
+        AddDecisionQueue("SETDQCONTEXT", $currentPlayer, "Choose a unit to give +" . $i . "/+" . $i, 1);
+        AddDecisionQueue("MAYCHOOSEMULTIZONE", $currentPlayer, "<-", 1);
+        AddDecisionQueue("APPENDDQVAR", $currentPlayer, 0, 1);
+        AddDecisionQueue("MZOP", $currentPlayer, "ADDHEALTH," . $i, 1);
+        AddDecisionQueue("MZOP", $currentPlayer, "GETUNIQUEID", 1);
+        AddDecisionQueue("ADDLIMITEDCURRENTEFFECT", $currentPlayer, "1939951561_" . $i . ",PLAY", 1);
+      }
+
       AddDecisionQueue("PASSPARAMETER", $currentPlayer, "-", 1);
       AddDecisionQueue("SETDQVAR", $currentPlayer, 0, 1);
       for($i=0; $i<2; ++$i) {

--- a/CoreLogic.php
+++ b/CoreLogic.php
@@ -3071,7 +3071,7 @@ function PlayAbility($cardID, $from, $resourcesPaid, $target = "-", $additionalC
         AddDecisionQueue("MZOP", $currentPlayer, "REDUCEHEALTH,2", 1);
         AddDecisionQueue("MZOP", $currentPlayer, "GETUNIQUEID", 1);
         AddDecisionQueue("ADDLIMITEDCURRENTEFFECT", $currentPlayer, "5013214638,PLAY", 1);
-        
+
         if (!HasFewerUnits($currentPlayer)) {
           break;
         }
@@ -4738,6 +4738,7 @@ function PlayAbility($cardID, $from, $resourcesPaid, $target = "-", $additionalC
     case "8061497086"://Perilous Position
       $ally = new Ally($target, MZPlayerID($currentPlayer, $target));
       $ally->Exhaust();
+      $ally->DefeatIfNoRemainingHP();
       break;
     case "8345985976"://Trade Federation Shuttle
       if(SearchCount(SearchAllies($currentPlayer, damagedOnly:true))) PlayAlly("3463348370", $currentPlayer);//Battle Droid

--- a/CoreLogic.php
+++ b/CoreLogic.php
@@ -5006,7 +5006,13 @@ function PlayAbility($cardID, $from, $resourcesPaid, $target = "-", $additionalC
       AddDecisionQueue("ADDLIMITEDCURRENTEFFECT", $currentPlayer, "8418001763,PLAY", 1);
       break;
     case "0216922902"://The Zillo Beast
-      AddCurrentTurnEffect("0216922902", $currentPlayer == 1 ? 2 : 1, "PLAY");
+      $otherPlayer = $currentPlayer == 1 ? 2 : 1;
+      $theirAllies = &GetTheirAllies($currentPlayer);
+      for ($i = 0; $i < count($theirAllies); $i += AllyPieces()) {
+        if (CardArenas($theirAllies[$i]) == "Ground") {
+          AddCurrentTurnEffect("0216922902", $otherPlayer, "PLAY", $theirAllies[$i+5]);
+        }
+      }
       break;
     case "2870878795"://Padme Amidala
       if(IsCoordinateActive($currentPlayer)) {

--- a/CoreLogic.php
+++ b/CoreLogic.php
@@ -5001,7 +5001,6 @@ function PlayAbility($cardID, $from, $resourcesPaid, $target = "-", $additionalC
       AddDecisionQueue("MZFILTER", $currentPlayer, "index=MYALLY-" . $playAlly->Index());
       AddDecisionQueue("SETDQCONTEXT", $currentPlayer, "Choose a unit to give +2/+2");
       AddDecisionQueue("MAYCHOOSEMULTIZONE", $currentPlayer, "<-", 1);
-      AddDecisionQueue("MZOP", $currentPlayer, "ADDHEALTH,2", 1);
       AddDecisionQueue("MZOP", $currentPlayer, "GETUNIQUEID", 1);
       AddDecisionQueue("ADDLIMITEDCURRENTEFFECT", $currentPlayer, "8418001763,PLAY", 1);
       break;

--- a/CurrentEffectAbilities.php
+++ b/CurrentEffectAbilities.php
@@ -109,7 +109,7 @@ function FinalizeChainLinkEffects()
   return false;
 }
 
-function EffectAttackModifier($effectCardID, $playerID="", $cardID="")
+function EffectAttackModifier($effectCardID, $playerID="")
 {
   global $mainPlayer, $defPlayer;
   $params = explode("_", $effectCardID);
@@ -611,8 +611,6 @@ function CurrentEffectEndTurnAbilities()
       case "8418001763"://Huyang
         if(SearchAlliesForCard($currentTurnEffects[$i+1], "8418001763")) {
           AddNextTurnEffect($currentTurnEffects[$i], $currentTurnEffects[$i + 1], $currentTurnEffects[$i + 2]);
-          $target = new Ally("MYALLY-" . SearchAlliesForUniqueID($currentTurnEffects[$i+2], $currentTurnEffects[$i+1]), $currentTurnEffects[$i+1]);
-          $target->AddRoundHealthModifier(2);
         }
         break;
       default: break;

--- a/CurrentEffectAbilities.php
+++ b/CurrentEffectAbilities.php
@@ -190,8 +190,7 @@ function EffectAttackModifier($effectCardID, $playerID="", $cardID="")
     case "fb7af4616c": return 1;//General Grievous
     case "3556557330": return 3;//Asajj Ventress
     case "8418001763": return 2;//Huyang
-    case "0216922902"://The Zillo Beast
-      return $cardID != "" && CardArenas($cardID) == "Ground" ? -5 : 0;
+    case "0216922902": return -5;//The Zillo Beast;
     case "7979348081": return 1;//Kraken
     default: return 0;
   }

--- a/CurrentEffectAbilities.php
+++ b/CurrentEffectAbilities.php
@@ -190,7 +190,7 @@ function EffectAttackModifier($effectCardID, $playerID="", $cardID="")
     case "fb7af4616c": return 1;//General Grievous
     case "3556557330": return 3;//Asajj Ventress
     case "8418001763": return 2;//Huyang
-    case "0216922902": return -5;//The Zillo Beast;
+    case "0216922902": return -5;//The Zillo Beast
     case "7979348081": return 1;//Kraken
     default: return 0;
   }

--- a/CurrentEffectAbilities.php
+++ b/CurrentEffectAbilities.php
@@ -109,16 +109,16 @@ function FinalizeChainLinkEffects()
   return false;
 }
 
-function EffectAttackModifier($effectCardID, $playerID="")
+function EffectAttackModifier($cardID, $playerID="")
 {
   global $mainPlayer, $defPlayer;
-  $params = explode("_", $effectCardID);
+  $params = explode("_", $cardID);
   if(count($params) == 1) {
-    $params = explode("-", $effectCardID);
+    $params = explode("-", $cardID);
   }
-  $effectCardID = $params[0];
+  $cardID = $params[0];
   if(count($params) > 1) $subparam = $params[1];
-  switch($effectCardID)
+  switch($cardID)
   {
     case "2587711125": return -4;//Disarm
     case "2569134232": return -4;//Jedha City

--- a/CurrentEffectAbilities.php
+++ b/CurrentEffectAbilities.php
@@ -109,16 +109,16 @@ function FinalizeChainLinkEffects()
   return false;
 }
 
-function EffectAttackModifier($cardID, $playerID="")
+function EffectAttackModifier($effectCardID, $playerID="", $cardID="")
 {
   global $mainPlayer, $defPlayer;
-  $params = explode("_", $cardID);
+  $params = explode("_", $effectCardID);
   if(count($params) == 1) {
-    $params = explode("-", $cardID);
+    $params = explode("-", $effectCardID);
   }
-  $cardID = $params[0];
+  $effectCardID = $params[0];
   if(count($params) > 1) $subparam = $params[1];
-  switch($cardID)
+  switch($effectCardID)
   {
     case "2587711125": return -4;//Disarm
     case "2569134232": return -4;//Jedha City
@@ -190,7 +190,8 @@ function EffectAttackModifier($cardID, $playerID="")
     case "fb7af4616c": return 1;//General Grievous
     case "3556557330": return 3;//Asajj Ventress
     case "8418001763": return 2;//Huyang
-    case "0216922902": return -5;//The Zillo Beast
+    case "0216922902"://The Zillo Beast
+      return $cardID != "" && CardArenas($cardID) == "Ground" ? -5 : 0;
     case "7979348081": return 1;//Kraken
     default: return 0;
   }

--- a/DecisionQueue/DecisionQueueEffects.php
+++ b/DecisionQueue/DecisionQueueEffects.php
@@ -625,7 +625,7 @@ function SpecificCardLogic($player, $card, $lastResult)
       PlayAlly("3941784506", $player);//Clone Trooper
       DealDamageAsync(($player == 1 ? 2 : 1), 2, "DAMAGE", "ad86d54e97");
       $char = &GetPlayerCharacter($player);
-      $char[CharacterPieces()] = "0026166404";
+      $char[CharacterPieces()] = "0026166404"; // Chancellor Palpatine Leader
       break;
     default: return "";
   }


### PR DESCRIPTION
## Fixes

- Zillo: Ensures the debuff only applies to ground targets and prevents it from affecting units played after Zillo is played.
- Perilous Position: Fixes an issue where 0 HP units were not properly defeated.
- Huyang: Fixes the buff so it functions correctly.
- Yoda leader: Prevent targeting the enemy leader on deploy.
- Chancellor Palpatine leader: Aspect penalty cost added.
