### PR TITLE
Bug fix for Enfys Nest 

### DIFF
--- a/AllyAbilities.php
+++ b/AllyAbilities.php
@@ -1883,7 +1883,7 @@ function SpecificAllyAttackAbilities($attackID)
       ExhaustResource($defPlayer);
       break;
     case "8414572243"://Enfys Nest
-      AddDecisionQueue("MULTIZONEINDICES", $mainPlayer, "THEIRALLY:maxAttack=4");
+      AddDecisionQueue("MULTIZONEINDICES", $mainPlayer, "THEIRALLY:maxAttack=" . $attackerAlly->CurrentPower() - 1);
       AddDecisionQueue("MZFILTER", $mainPlayer, "definedType=Leader");
       AddDecisionQueue("SETDQCONTEXT", $mainPlayer, "Choose a card to bounce");
       AddDecisionQueue("MAYCHOOSEMULTIZONE", $mainPlayer, "<-", 1);


### PR DESCRIPTION
### Fixes

- Enfys Nest: use the current power instead of the printed power to bounce enemies.