### PR TITLE
refactor: encapsulate logging and use borders

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,21 @@
+name: CI
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  build-test:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v3
+    - uses: php-actions/composer@v6
+    - uses: php-actions/phpunit@v3
+      with:
+        args: --testdox
+

--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,5 @@ HostFiles
 composer.phar
 composer.lock
 vendor/
+
+.phpunit.result.cache

--- a/APIs/CreateGame.php
+++ b/APIs/CreateGame.php
@@ -4,6 +4,7 @@ ob_start();
 include "../HostFiles/Redirector.php";
 include "../Libraries/HTTPLibraries.php";
 include "../Libraries/SHMOPLibraries.php";
+include "../WriteLog.php";
 include_once "../Libraries/PlayerSettings.php";
 include_once '../Assets/patreon-php-master/src/PatreonDictionary.php';
 require_once '../Assets/patreon-php-master/src/API.php';
@@ -122,9 +123,7 @@ $gameFileHandler = fopen($filename, "w");
 include "../MenuFiles/WriteGamefile.php";
 WriteGameFile();
 
-$filename = "../Games/" . $gameName . "/gamelog.txt";
-$handler = fopen($filename, "w");
-fclose($handler);
+CreateLog($gameName, "../");
 
 $currentTime = round(microtime(true) * 1000);
 $cacheVisibility = ($visibility == "public" ? "1" : "0");

--- a/APIs/GetLobbyRefresh.php
+++ b/APIs/GetLobbyRefresh.php
@@ -132,7 +132,7 @@ if ($lastUpdate != 0 && $cacheVal < $lastUpdate) {
     $response->isPrivateLobby = ($visibility == "private");
   }
 
-  $response->gameLog = JSONLog($gameName, $playerID, "../");
+  $response->gameLog = JSONLog($gameName, "../");
 
   $response->playAudio = ($playerID == 1 && $gameStatus == $MGS_ChooseFirstPlayer ? 1 : 0);
 

--- a/APIs/SubmitSideboard.php
+++ b/APIs/SubmitSideboard.php
@@ -10,6 +10,7 @@ include "../Libraries/StatFunctions.php";
 include "../Libraries/PlayerSettings.php";
 include "../Libraries/UILibraries2.php";
 include "../AI/CombatDummy.php";
+include "../WriteLog.php";
 include_once "../includes/dbh.inc.php";
 include_once "../includes/functions.inc.php";
 include_once "../MenuFiles/StartHelper.php";
@@ -159,7 +160,7 @@ if($p1SideboardSubmitted == "1" && $p2SideboardSubmitted == "1") {
   WriteGamestateCache($gameName, $gamestate);
 
   //Set up log file
-  $filename = "../Games/" . $gameName . "/gamelog.txt";
+  $filename = LogPath($gameName, "../");
   $filepath = "../Games/" . $gameName . "/";
   $handler = fopen($filename, "w");
   fclose($handler);

--- a/ChooseFirstPlayer.php
+++ b/ChooseFirstPlayer.php
@@ -1,6 +1,6 @@
 <?php
 
-include "WriteLog.php";
+include_once "WriteLog.php";
 include "Libraries/HTTPLibraries.php";
 include "Libraries/SHMOPLibraries.php";
 

--- a/CreateGame.php
+++ b/CreateGame.php
@@ -4,6 +4,7 @@ ob_start();
 include "HostFiles/Redirector.php";
 include "Libraries/HTTPLibraries.php";
 include "Libraries/SHMOPLibraries.php";
+include_once "WriteLog.php";
 include_once "Libraries/PlayerSettings.php";
 include_once 'Assets/patreon-php-master/src/PatreonDictionary.php';
 include_once "./AccountFiles/AccountDatabaseAPI.php";
@@ -116,9 +117,7 @@ $gameFileHandler = fopen($filename, "w");
 include "MenuFiles/WriteGamefile.php";
 WriteGameFile();
 
-$filename = "./Games/" . $gameName . "/gamelog.txt";
-$handler = fopen($filename, "w");
-fclose($handler);
+CreateLog($gameName);
 
 $currentTime = round(microtime(true) * 1000);
 $cacheVisibility = ($visibility == "public" ? "1" : "0");

--- a/CreateReplayGame.php
+++ b/CreateReplayGame.php
@@ -5,6 +5,7 @@ ob_start();
 include "HostFiles/Redirector.php";
 include "Libraries/HTTPLibraries.php";
 include "Libraries/SHMOPLibraries.php";
+include_once "WriteLog.php";
 include_once "Libraries/PlayerSettings.php";
 include_once 'Assets/patreon-php-master/src/PatreonDictionary.php';
 ob_end_clean();
@@ -51,9 +52,7 @@ $gameFileHandler = fopen($filename, "w");
 include "MenuFiles/WriteGamefile.php";
 WriteGameFile();
 
-$filename = "./Games/" . $gameName . "/gamelog.txt";
-$handler = fopen($filename, "w");
-fclose($handler);
+CreateLog($gameName);
 
 $currentTime = round(microtime(true) * 1000);
 $isReplay = "1";

--- a/GameLobby.php
+++ b/GameLobby.php
@@ -1,6 +1,5 @@
 <?php
 ob_start();
-include "WriteLog.php";
 include "CardDictionary.php";
 include "HostFiles/Redirector.php";
 include "Libraries/UILibraries2.php";
@@ -8,6 +7,7 @@ include "Libraries/SHMOPLibraries.php";
 include_once "Libraries/PlayerSettings.php";
 include_once "Libraries/HTTPLibraries.php";
 include_once "Assets/patreon-php-master/src/PatreonDictionary.php";
+include_once "WriteLog.php";
 ob_end_clean();
 
 session_start();
@@ -78,6 +78,7 @@ $isMobile = IsMobile();
   <meta http-equiv="content-type" content="text/html; charset=utf-8" >
   <title>Game Lobby</title>
   <link id="icon" rel="shortcut icon" type="image/png" href="./Images/<?= $icon ?>"/>
+  <link rel="stylesheet" href="./css/chat.css">
   <link rel="stylesheet" href="./css/karabast122924.css">
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
@@ -87,7 +88,7 @@ $isMobile = IsMobile();
 
 
 
-<body onload='OnLoadCallback(<?php echo (filemtime("./Games/" . $gameName . "/gamelog.txt")); ?>)'>
+<body onload='OnLoadCallback(<?php echo (filemtime(LogPath($gameName))); ?>)'>
   <div class="lobby-container">
     <div id="cardDetail" style="display:none; position:absolute;"></div>
     <div class="lobby-header">

--- a/GameLogic.php
+++ b/GameLogic.php
@@ -1511,7 +1511,8 @@ function DecisionQueueStaticEffect($phase, $player, $parameter, $lastResult)
         $ally->Exhaust();
       }
       $names = explode(",", GetAbilityNames($parameter, GetClassState($player, $CS_PlayIndex)));
-      WriteLog(implode(" ", explode("_", $names[$index])) . " ability was chosen.");
+      $ability = implode(" ", explode("_", $names[$index]));
+      WriteLog("<b><span style='color:Gray'>{$ability}</span></b> ability was chosen.");
       return $lastResult;
       case "SETABILITYTYPEOPP"://For activating opponent's cards
         global $CS_OppIndex, $CS_OppCardActive;

--- a/GetLobbyRefresh.php
+++ b/GetLobbyRefresh.php
@@ -20,10 +20,10 @@ if(!file_exists("./Games/" . $gameName . "/")) { header('HTTP/1.0 403 Forbidden'
 if($lastUpdate == "NaN") $lastUpdate = 0;
 if ($lastUpdate > 10000000) $lastUpdate = 0;
 
-include "WriteLog.php";
 include "HostFiles/Redirector.php";
 include "Libraries/UILibraries2.php";
 include "Libraries/SHMOPLibraries.php";
+include_once "WriteLog.php";
 
 $data = array();
 $currentTime = round(microtime(true) * 1000);

--- a/GetLobbyRefresh.php
+++ b/GetLobbyRefresh.php
@@ -126,7 +126,7 @@ if ($lastUpdate != 0 && $cacheVal < $lastUpdate) {
   $data["showSubmit"] = $showSubmit;
 
   // Chat Log
-  $data["logContent"] = JSONLog($gameName, $playerID);
+  $data["logContent"] = JSONLog($gameName);
 
   // Player Joined Audio
   $data["playerJoinAudio"] = $playerID == 1 && $gameStatus == $MGS_ChooseFirstPlayer;

--- a/GetNextTurn2.php
+++ b/GetNextTurn2.php
@@ -33,7 +33,7 @@ if (($playerID == 1 || $playerID == 2) && $authKey == "") {
 
 include "HostFiles/Redirector.php";
 include "Libraries/SHMOPLibraries.php";
-include "WriteLog.php";
+include_once "WriteLog.php";
 
 SetHeaders();
 

--- a/GetNextTurn2.php
+++ b/GetNextTurn2.php
@@ -1114,7 +1114,7 @@ if ($lastUpdate != 0 && $cacheVal <= $lastUpdate) {
   echo ("</div>");
 
   echo ("<div id='gamelog'>");
-  EchoLog($gameName, $playerID);
+  EchoLog($gameName);
   echo ("</div>");
   if ($playerID != 3) {
     echo ("<div id='chatPlaceholder'></div>");

--- a/GetNextTurn3.php
+++ b/GetNextTurn3.php
@@ -645,7 +645,7 @@ if ($lastUpdate != 0 && $cacheVal <= $lastUpdate) {
   $response->landmarks = $landmarksOutput;
 
   // Chat Log
-  $response->chatLog = JSONLog($gameName, $playerID);
+  $response->chatLog = JSONLog($gameName);
 
   // Deduplicate current turn effects
   $playerEffects = array();

--- a/GetNextTurn3.php
+++ b/GetNextTurn3.php
@@ -3,7 +3,7 @@
 include 'Libraries/HTTPLibraries.php';
 include "HostFiles/Redirector.php";
 include "Libraries/SHMOPLibraries.php";
-include "WriteLog.php";
+include_once "WriteLog.php";
 
 // array holding allowed Origin domains
 SetHeaders();

--- a/GetUpdateSSE.php
+++ b/GetUpdateSSE.php
@@ -3,7 +3,7 @@
 include 'Libraries/HTTPLibraries.php';
 include "HostFiles/Redirector.php";
 include "Libraries/SHMOPLibraries.php";
-include "WriteLog.php";
+include_once "WriteLog.php";
 
 // array holding allowed Origin domains
 SetHeaders();

--- a/JoinGameInput.php
+++ b/JoinGameInput.php
@@ -1,6 +1,5 @@
 <?php
 
-include "WriteLog.php";
 include "Libraries/HTTPLibraries.php";
 include "Libraries/SHMOPLibraries.php";
 include "APIKeys/APIKeys.php";
@@ -8,6 +7,7 @@ include_once 'includes/functions.inc.php';
 include_once 'includes/dbh.inc.php';
 include_once 'CoreLogic.php';
 include_once 'Libraries/CoreLibraries.php';
+include_once "WriteLog.php";
 
 include_once 'LZCompressor/LZContext.php';
 include_once 'LZCompressor/LZData.php';

--- a/Libraries/NetworkingLibraries.php
+++ b/Libraries/NetworkingLibraries.php
@@ -567,7 +567,7 @@ function ProcessInput($playerID, $mode, $buttonInput, $cardID, $chkCount, $chkIn
       mkdir($folderName, 0700, true);
       copy("./Games/$gameName/gamestate.txt", $folderName . "/gamestate.txt");
       copy("./Games/$gameName/gamestateBackup.txt", $folderName . "/gamestateBackup.txt");
-      copy("./Games/$gameName/gamelog.txt", $folderName . "/gamelog.txt");
+      copy(LogPath($gameName), $folderName . "/gamelog.txt");
       copy("./Games/$gameName/beginTurnGamestate.txt", $folderName . "/beginTurnGamestate.txt");
       copy("./Games/$gameName/lastTurnGamestate.txt", $folderName . "/lastTurnGamestate.txt");
       WriteLog("Thank you for reporting a bug. To describe what happened, please report it on the discord server with the game number for reference (" . $gameName . "-" . $bugCount . ").");
@@ -650,7 +650,7 @@ function ProcessInput($playerID, $mode, $buttonInput, $cardID, $chkCount, $chkIn
       mkdir($folderName, 0700, true);
       copy("./Games/$gameName/gamestate.txt", $folderName . "/gamestate.txt");
       copy("./Games/$gameName/gamestateBackup.txt", $folderName . "/gamestateBackup.txt");
-      copy("./Games/$gameName/gamelog.txt", $folderName . "/gamelog.txt");
+      copy(LogPath($gameName), $folderName . "/gamelog.txt");
       copy("./Games/$gameName/beginTurnGamestate.txt", $folderName . "/beginTurnGamestate.txt");
       copy("./Games/$gameName/lastTurnGamestate.txt", $folderName . "/lastTurnGamestate.txt");
       WriteLog("Thank you for reporting the player. The chat log has been saved to the server. Please report it to mods on the discord server with the game number for reference ($gameName).");

--- a/NextTurn4.php
+++ b/NextTurn4.php
@@ -49,7 +49,6 @@
 
     //First we need to parse the game state from the file
     include "Libraries/SHMOPLibraries.php";
-    include "WriteLog.php";
     include "ParseGamestate.php";
     include "GameTerms.php";
     include "GameLogic.php";
@@ -58,6 +57,7 @@
     include "Libraries/StatFunctions.php";
     include "Libraries/PlayerSettings.php";
     include "MenuFiles/ParseGamefile.php";
+    include_once "WriteLog.php";
     include_once 'includes/functions.inc.php';
     include_once 'includes/dbh.inc.php';
 
@@ -82,6 +82,7 @@
     <head>
       <meta charset="utf-8">
       <title>Karabast</title>
+      <link rel="stylesheet" href="./css/chat.css">
       <link rel="stylesheet" href="css/gamestyle072724.css">
       <link rel="preconnect" href="https://fonts.googleapis.com">
       <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
@@ -503,7 +504,7 @@
 
   </head>
 
-  <body onkeypress='Hotkeys(event)' onload='OnLoadCallback(<?php echo (filemtime("./Games/" . $gameName . "/gamelog.txt")); ?>)'>
+  <body onkeypress='Hotkeys(event)' onload='OnLoadCallback(<?php echo (filemtime(LogPath($gameName))); ?>)'>
 
     <?php echo (CreatePopup("inactivityWarningPopup", [], 0, 0, "⚠️ Inactivity Warning ⚠️", 1, "", "", true, true, "Interact with the screen in the next 30 seconds or you could be kicked for inactivity.")); ?>
     <?php echo (CreatePopup("inactivePopup", [], 0, 0, "⚠️ You are Inactive ⚠️", 1, "", "", true, true, "You are inactive. Your opponent is able to claim victory. Interact with the screen to clear this.")); ?>

--- a/ProcessInput2.php
+++ b/ProcessInput2.php
@@ -3,7 +3,6 @@
 error_reporting(E_ALL);
 ob_start();
 
-include "WriteLog.php";
 include "GameLogic.php";
 include "GameTerms.php";
 include "HostFiles/Redirector.php";
@@ -20,6 +19,7 @@ require_once("Libraries/CoreLibraries.php");
 include_once "./includes/dbh.inc.php";
 include_once "./includes/functions.inc.php";
 include_once "APIKeys/APIKeys.php";
+include_once "WriteLog.php";
 
 //We should always have a player ID as a URL parameter
 $gameName = TryGET("gameName", "");

--- a/ProcessInputAPI.php
+++ b/ProcessInputAPI.php
@@ -2,7 +2,6 @@
 
 error_reporting(E_ALL);
 
-include "WriteLog.php";
 include "GameLogic.php";
 include "GameTerms.php";
 include "HostFiles/Redirector.php";
@@ -19,6 +18,7 @@ require_once("Libraries/CoreLibraries.php");
 include_once "./includes/dbh.inc.php";
 include_once "./includes/functions.inc.php";
 include_once "APIKeys/APIKeys.php";
+include_once "WriteLog.php";
 
 SetHeaders();
 $_POST = json_decode(file_get_contents('php://input'), true);

--- a/SimulateGame.php
+++ b/SimulateGame.php
@@ -5,7 +5,6 @@ ini_set('display_startup_errors', 1);
 error_reporting(E_ALL);
 
 ob_start();
-include "WriteLog.php";
 include "GameLogic.php";
 include "GameTerms.php";
 include "HostFiles/Redirector.php";
@@ -21,6 +20,7 @@ require_once("Libraries/CoreLibraries.php");
 include_once "./includes/dbh.inc.php";
 include_once "./includes/functions.inc.php";
 include_once "APIKeys/APIKeys.php";
+include_once "WriteLog.php";
 ob_end_clean();
 
 $gameName = $_GET["gameName"];

--- a/Start.php
+++ b/Start.php
@@ -11,6 +11,7 @@ include "Libraries/StatFunctions.php";
 include "Libraries/PlayerSettings.php";
 include "Libraries/UILibraries2.php";
 include "AI/CombatDummy.php";
+include_once "WriteLog.php";
 include_once "./includes/dbh.inc.php";
 include_once "./includes/functions.inc.php";
 include_once "./MenuFiles/StartHelper.php";
@@ -88,9 +89,7 @@ fwrite($handler, "-");//Effect Context
 fclose($handler);
 
 //Set up log file
-$filename = "./Games/" . $gameName . "/gamelog.txt";
-$handler = fopen($filename, "w");
-fclose($handler);
+CreateLog($gameName);
 
 $currentTime = strval(round(microtime(true) * 1000));
 $currentUpdate = GetCachePiece($gameName, 1);

--- a/StartEffects.php
+++ b/StartEffects.php
@@ -1,7 +1,7 @@
 <?php
 
 //include "ParseGamestate.php";
-//include "WriteLog.php";
+//include_once "WriteLog.php";
 
 array_push($layerPriority, ShouldHoldPriority(1), ShouldHoldPriority(2));
 

--- a/SubmitChat.php
+++ b/SubmitChat.php
@@ -2,6 +2,8 @@
 
 include "Libraries/HTTPLibraries.php";
 include "Libraries/SHMOPLibraries.php";
+include_once "WriteLog.php";
+
 SetHeaders();
 
 $gameName = $_GET["gameName"];
@@ -46,12 +48,10 @@ $filteredChatText = str_replace("faggot", "****", $filteredChatText);
 $filteredChatText = str_replace("kill yourself", "****", $filteredChatText);
 $filteredChatText = str_replace("die in a fire", "****", $filteredChatText);
 
-$filename = "./Games/" . $gameName . "/gamelog.txt";
-$handler = fopen($filename, "a");
-$output = "<span style='font-weight:bold; color:<PLAYER" . $playerID . "COLOR>;'>" . $displayName . ": </span>" . $filteredChatText;
-fwrite($handler, $output . "\r\n");
-if (GetCachePiece($gameName, 11) >= 3) fwrite($handler, "The lobby is reactivated.\r\n");
-fclose($handler);
+if (GetCachePiece($gameName, 11) >= 3) {
+  WriteLog("The lobby is reactivated");
+}
+WriteLog("<span class='player$playerID-label bold'>$displayName</span>: $filteredChatText");
 
 GamestateUpdated($gameName);
 if ($playerID == 1) SetCachePiece($gameName, 11, 0);

--- a/SubmitSideboard.php
+++ b/SubmitSideboard.php
@@ -13,9 +13,9 @@ $playerCharacter = $_GET["playerCharacter"];
 $playerDeck = $_GET["playerDeck"];
 $authKey = $_GET["authKey"];
 
-include "WriteLog.php";
 include "HostFiles/Redirector.php";
 include "CardDictionary.php";
+include_once "WriteLog.php";
 
 include "MenuFiles/ParseGamefile.php";
 include "MenuFiles/WriteGamefile.php";

--- a/WriteLog.php
+++ b/WriteLog.php
@@ -60,34 +60,28 @@ function WriteError($text)
   WriteLog("ERROR: " . $text);
 }
 
-function EchoLog($gameName, $playerID)
+function EchoLog($gameName)
 {
   $filename = LogPath($gameName);
   $filesize = filesize($filename);
-  if ($filesize > 0) {
-    $handler = fopen($filename, "r");
-    $line = fread($handler, $filesize);
-    echo ($line);
+  if ($filesize > 0 && ($handler = fopen($filename, "r"))) {
+    echo(fread($handler, $filesize));
     fclose($handler);
   }
 }
 
-function JSONLog($gameName, $playerID, $path="./")
+function JSONLog($gameName, $path="./")
 {
-  $response = "";
   $filename = LogPath($gameName, $path);
   $filesize = filesize($filename);
-  if ($filesize > 0) {
-    $handler = fopen($filename, "r");
-    $line = str_replace("\r\n", "<br>", fread($handler, $filesize));
-    //$line = str_replace("<PLAYER1COLOR>", $playerID==1 ? "Blue" : "Red", $line);
-    //$line = str_replace("<PLAYER2COLOR>", $playerID==2 ? "Blue" : "Red", $line);
-    $red = "#cb0202";
-    $blue = "#128ee5";
-    $line = str_replace("<PLAYER1COLOR>", $playerID == 1 || $playerID == 3 ? $blue : $red, $line);
-    $line = str_replace("<PLAYER2COLOR>", $playerID == 2 ? $blue : $red, $line);
-    $response = $line;
-    fclose($handler);
+
+  if ($filesize <= 0) {
+    return "";
   }
+
+  $handler = fopen($filename, "r");
+  $response = fread($handler, $filesize);
+  fclose($handler);
+
   return $response;
 }

--- a/WriteLog.php
+++ b/WriteLog.php
@@ -1,14 +1,30 @@
 <?php
 
-function WriteLog($text, $playerColor = 0, $highlight=false, $path="./")
+function LogPath($gameName, $path="./")
+{
+  return "{$path}Games/$gameName/gamelog.txt";
+}
+
+function CreateLog($gameName, $path="./")
+{
+  fclose(fopen(LogPath($gameName, $path), "w")); 
+}
+
+function WriteLog($text, $player = 0, $highlight=false, $path="./")
 {
   global $gameName;
-  $filename = $path . "Games/" . $gameName . "/gamelog.txt";
-  $handler = fopen($filename, "a");
-  if(!$handler) return;//File does not exist
-  if($highlight) $output =  ($playerColor != 0 ? "<span style='color:<PLAYER" . $playerColor . "COLOR>; '>" : "") . "<mark style='background-color: brown; color:azure;'>" . $text . "</mark>" . ($playerColor != 0 ? "</span>" : "");
-  else $output = ($playerColor != 0 ? "<span style='color:<PLAYER" . $playerColor . "COLOR>; '>" : "")  . $text . ($playerColor != 0 ? "</span>" : "");
-  fwrite($handler, $output . "\r\n");
+
+  if(!($handler = fopen(LogPath($gameName, $path), "a"))) {
+    //File does not exist
+    return;
+  }
+  
+  $output = $highlight ? "<mark style='background-color: brown; color:azure;'>$text</mark>" : $text;
+  $output = $player != 0 ? "<span class='player$player-label'>$output</span>" : $output;
+  $output = "<p class='log-entry'>$output</p>";
+  $output = $output . "\r\n";
+  
+  fwrite($handler, $output);
   fclose($handler);
 }
 
@@ -21,8 +37,8 @@ function ClearLog($n=20)
   fclose($handler);
   */
 
-  $filename = "./Games/" . $gameName . "/gamelog.txt";
-  $handle = fopen("./Games/" . $gameName . "/gamelog.txt", "r");
+  $filename = LogPath($gameName);
+  $handle = fopen($filename, "r");
   $lines = array_fill(0, $n-1, '');
   if ($handle) {
     while (!feof($handle)) {
@@ -46,17 +62,11 @@ function WriteError($text)
 
 function EchoLog($gameName, $playerID)
 {
-  $filename = "./Games/" . $gameName . "/gamelog.txt";
+  $filename = LogPath($gameName);
   $filesize = filesize($filename);
   if ($filesize > 0) {
     $handler = fopen($filename, "r");
-    $line = str_replace("\r\n", "<br>", fread($handler, $filesize));
-    //$line = str_replace("<PLAYER1COLOR>", $playerID==1 ? "Blue" : "Red", $line);
-    //$line = str_replace("<PLAYER2COLOR>", $playerID==2 ? "Blue" : "Red", $line);
-    $red = "#cb0202";
-    $blue = "#128ee5";
-    $line = str_replace("<PLAYER1COLOR>", $playerID == 1 || $playerID == 3 ? $blue : $red, $line);
-    $line = str_replace("<PLAYER2COLOR>", $playerID == 2 ? $blue : $red, $line);
+    $line = fread($handler, $filesize);
     echo ($line);
     fclose($handler);
   }
@@ -65,7 +75,7 @@ function EchoLog($gameName, $playerID)
 function JSONLog($gameName, $playerID, $path="./")
 {
   $response = "";
-  $filename = $path . "Games/" . $gameName . "/gamelog.txt";
+  $filename = LogPath($gameName, $path);
   $filesize = filesize($filename);
   if ($filesize > 0) {
     $handler = fopen($filename, "r");

--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,8 @@
 {
   "require": {
     "sendgrid/sendgrid": "~7"
+  },
+  "require-dev": {
+    "phpunit/phpunit": "^11"
   }
 }

--- a/css/chat.css
+++ b/css/chat.css
@@ -1,0 +1,20 @@
+.log-entry {
+    background-color: rgba(255, 255, 255, 0.1);
+    margin: 8px 0px;
+    padding: 4px 8px;
+    border-left: solid 2px #afafaf;
+    border-right: solid 2px #afafaf;
+    border-radius: 4px;
+}
+
+.player1-label {
+    color: #128ee5;
+}
+
+.player2-label {
+    color: #cb0202;
+}
+
+.bold {
+    font-weight: bold;
+}

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"     
+  xsi:noNamespaceSchemaLocation="./vendor/phpunit/phpunit/phpunit.xsd"     
+  displayDetailsOnTestsThatTriggerWarnings="true"
+  colors="true">
+  <!-- rest of the config file -->
+</phpunit>

--- a/tests/WriteLogTest.php
+++ b/tests/WriteLogTest.php
@@ -1,0 +1,60 @@
+<?php declare(strict_types=1);
+use PHPUnit\Framework\TestCase;
+
+include_once "./WriteLog.php";
+
+final class WriteLogTest extends TestCase
+{
+    public function setUp(): void {
+        $gameName = $GLOBALS["gameName"] = "test";
+        
+        mkdir("./Games/$gameName", 0700, true);
+    }
+
+    public function tearDown(): void {
+        global $gameName;
+        if (file_exists(LogPath($gameName)))
+            unlink(LogPath($gameName));
+        rmdir("./Games/$gameName");
+    }
+
+    public function testLogPath(): void
+    {
+        global $gameName;
+        $this->assertEquals(LogPath($gameName), "./Games/$gameName/gamelog.txt");
+    }
+
+    public function testWriteLog(): void
+    {
+        global $gameName;
+        
+        CreateLog($gameName);
+        WriteLog($msg = "test log entry");
+        EchoLog($gameName);
+
+        $this->assertFileExists(LogPath($gameName));
+        $this->expectOutputString("<p class='log-entry'>{$msg}</p>\r\n");
+    }
+
+    public function testWriteLogWithPlayerId(): void
+    {
+        global $gameName;
+        
+        CreateLog($gameName);
+        WriteLog($msg = "test log entry", 1);
+        EchoLog($gameName);
+
+        $this->assertFileExists(LogPath($gameName));
+        $this->expectOutputString("<p class='log-entry'><span class='player1-label'>{$msg}</span></p>\r\n");
+    }
+
+    public function testJsonLog(): void
+    {
+        global $gameName;
+        
+        CreateLog($gameName);
+        WriteLog($msg = "test log entry");
+        
+        $this->assertEquals("<p class='log-entry'>{$msg}</p>\r\n", JSONLog($gameName));
+    }
+}


### PR DESCRIPTION
We refactor some of the logic around game logging to DRY some path computations. We also add some style to make individual log entries easier to spot using borders and transparent background colors.

This is what the in-game chat looks like with this change

![image](https://github.com/user-attachments/assets/30401616-dfc1-45a4-b93b-b405841cb261)
