### PR TITLE
ci: fix phpunit command arguments

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,5 +17,5 @@ jobs:
     - uses: php-actions/composer@v6
     - uses: php-actions/phpunit@v3
       with:
-        args: --testdox
-
+        test_suffix: Test.php
+        args: --testdox tests


### PR DESCRIPTION
We fix the arguments to the phpunit GH action to allow it to run the unit tests under tests/