### PR TITLE
refactor: initiative token bi-state

### DIFF
--- a/GetNextTurn2.php
+++ b/GetNextTurn2.php
@@ -305,10 +305,11 @@ if ($lastUpdate != 0 && $cacheVal <= $lastUpdate) {
     $top = 15;
   }
 
+  $initiativeSuffix = $initiativeTaken ? "-taken" : "";
   if($initiativePlayer == $playerID || ($playerID == 3 && $initiativePlayer == 2)) {
-    echo ("<div class='my-initiative'><span>Initiative</span>");
+    echo ("<div class='my-initiative$initiativeSuffix'><span>Initiative</span>");
   } else {
-    echo ("<div class='their-initiative'><span>Initiative</span>");
+    echo ("<div class='their-initiative$initiativeSuffix'><span>Initiative</span>");
   }
   echo ("</div>");
 

--- a/css/gamestyle072724.css
+++ b/css/gamestyle072724.css
@@ -94,8 +94,7 @@ td {
   z-index: 10; 
   background:black; 
   font-size: 16px; 
-  font-weight: 500; 
-  color:white; 
+  font-weight: bold;
   user-select: none;
 }
 
@@ -358,33 +357,68 @@ td {
 
 /* Initiative */
 
-.my-initiative, .their-initiative {
-  right:258px; 
-  position:absolute; 
-  border-radius: 15px; 
+.my-initiative,
+.their-initiative,
+.my-initiative-taken,
+.their-initiative-taken {
+  right: 258px;
+  position: absolute;
+  border-radius: 20px;
+  border-width: 4px;
+  border-style: solid;
   height: 30px; 
   width: 96px; 
 }
 
-.my-initiative span, .their-initiative span {
-  position:relative; 
+.my-initiative span,
+.their-initiative span,
+.my-initiative-taken span,
+.their-initiative-taken span {
+  position: relative;
   margin: 5px auto 0; 
   text-align: center; 
-  display:block; 
-  z-index:10; 
+  display: block;
+  z-index: 10;
   font-size: 16px; 
-  font-weight:600; 
-  color:black; user-select: none;
+  font-weight: 600;
+  user-select: none;
 }
 
 .my-initiative {
-  bottom:127px; 
-  background: #00BAFF; 
+  bottom: 127px;
+  background: transparent;
+  border-color: #18c1ff;
 }
 
 .their-initiative {
-  top:127px; 
-  background: #FB0007; 
+  top: 127px;
+  background: rgba(80, 0, 0, 0.5);
+  border-color: #ff2930;
+}
+
+.my-initiative-taken {
+  bottom: 127px;
+  background-color: #18c1ff;
+  border-color: #18c1ff;
+}
+
+.their-initiative-taken {
+  top: 127px;
+  background: #ff2930;
+  border-color: #ff2930;
+}
+
+.my-initiative span {
+  color: #18c1ff;
+}
+
+.their-initiative span {
+  color: #ff2930;
+}
+
+.my-initiative-taken span,
+.their-initiative-taken span {
+  color: white;
 }
 
 /* Units */


### PR DESCRIPTION
We refactor the style and the logic to allow for a 2-state initiative token that makes it easier to see when a player has claimed the initiative.

**Unclaimed**
<img width="125" alt="Screenshot 2025-01-11 at 17 20 25" src="https://github.com/user-attachments/assets/94b73b1f-fbf5-4493-883b-81b4b1a9c83e" />

**Claimed**
<img width="125" alt="Screenshot 2025-01-11 at 17 20 44" src="https://github.com/user-attachments/assets/e606724e-d5c9-4fc0-8f3a-23228633107e" />
