### PR TITLE
fix(Asajj Ventress): Automatically trigger Asajj Ventress' on-attack ability

### DIFF
--- a/AllyAbilities.php
+++ b/AllyAbilities.php
@@ -2068,11 +2068,10 @@ function SpecificAllyAttackAbilities($attackID)
       AddDecisionQueue("ADDLIMITEDCURRENTEFFECT", $mainPlayer, "fb7af4616c,HAND", 1);
       break;
     case "3556557330"://Asajj Ventress
-      AddDecisionQueue("YESNO", $mainPlayer, "Have you attacked with another Separatist?");
-      AddDecisionQueue("NOPASS", $mainPlayer, "-");
-      AddDecisionQueue("NOPASS", $mainPlayer, "-");
-      AddDecisionQueue("PASSPARAMETER", $mainPlayer, $attackerAlly->UniqueID(), 1);
-      AddDecisionQueue("ADDLIMITEDCURRENTEFFECT", $mainPlayer, "3556557330,PLAY", 1);
+      if(AnotherSeparatistUnitHasAttacked($attackerAlly->UniqueID(), $mainPlayer)) {
+        AddDecisionQueue("PASSPARAMETER", $mainPlayer, $attackerAlly->UniqueID(), 1);
+        AddDecisionQueue("ADDLIMITEDCURRENTEFFECT", $mainPlayer, "3556557330,PLAY", 1);
+      }
       break;
     case "f8e0c65364"://Asajj Ventress (deployed leader)
       global $CS_NumEventsPlayed;

--- a/Constants.php
+++ b/Constants.php
@@ -281,6 +281,7 @@ $CS_UnitsThatAttackedBase = 67;
 $CS_OppIndex = 68;
 $CS_OppCardActive = 69;
 $CS_PlayedWithExploit = 70;
+$CS_SeparatistUnitsThatAttacked = 71;
 
 function SetAfterPlayedBy($player, $cardID)
 {
@@ -469,7 +470,7 @@ function ResetClassState($player)
   global $CS_PreparationCounters, $CS_NextNAACardGoAgain, $CS_NumAlliesDestroyed, $CS_Num6PowBan, $CS_ResolvingLayerUniqueID, $CS_NextWizardNAAInstant;
   global $CS_ArcaneDamageTaken, $CS_NextNAAInstant, $CS_NextDamagePrevented, $CS_LastAttack, $CS_PlayCCIndex;
   global $CS_NumLeftPlay, $CS_NumMaterializations, $CS_NumFusedLightning, $CS_AfterPlayedBy, $CS_NumAttackCards, $CS_NumPlayedFromBanish;
-  global $CS_NumAttacks, $CS_DieRoll, $CS_NumMandalorianAttacks, $CS_NumWizardNonAttack, $CS_LayerTarget, $CS_NumSwordAttacks;
+  global $CS_NumAttacks, $CS_DieRoll, $CS_NumMandalorianAttacks, $CS_SeparatistUnitsThatAttacked, $CS_NumWizardNonAttack, $CS_LayerTarget, $CS_NumSwordAttacks;
   global $CS_HitsWithWeapon, $CS_ArcaneDamagePrevention, $CS_DynCostResolved, $CS_CardsEnteredGY, $CS_CachedCharacterLevel, $CS_ArsenalFacing;
   global $CS_HighestRoll, $CS_NumAuras, $CS_AbilityIndex, $CS_AdditionalCosts, $CS_NumRedPlayed, $CS_PlayUniqueID, $CS_AlluvionUsed;
   global $CS_NumPhantasmAADestroyed, $CS_NumEventsPlayed, $CS_MaxQuellUsed, $CS_DamageDealt, $CS_ArcaneTargetsSelected, $CS_NumDragonAttacks, $CS_NumIllusionistAttacks;
@@ -511,6 +512,7 @@ function ResetClassState($player)
   $classState[$CS_NumAttacks] = 0;
   $classState[$CS_DieRoll] = 0;
   $classState[$CS_NumMandalorianAttacks] = 0;
+  $classState[$CS_SeparatistUnitsThatAttacked] = "-";
   $classState[$CS_NumWizardNonAttack] = 0;
   $classState[$CS_LayerTarget] = "-";
   $classState[$CS_NumSwordAttacks] = 0;

--- a/Libraries/NetworkingLibraries.php
+++ b/Libraries/NetworkingLibraries.php
@@ -1757,7 +1757,7 @@ function PlayCardEffect($cardID, $from, $resourcesPaid, $target = "-", $addition
   global $CS_CharacterIndex, $CS_NumNonAttackCards, $CS_PlayCCIndex, $CS_NumAttacks, $CCS_LinkBaseAttack;
   global $CCS_WeaponIndex, $EffectContext, $CCS_AttackUniqueID, $CS_NumEventsPlayed, $CS_AfterPlayedBy, $layers;
   global $CS_NumDragonAttacks, $CS_NumIllusionistAttacks, $CS_NumIllusionistActionCardAttacks, $CCS_IsBoosted;
-  global $SET_PassDRStep, $CS_AbilityIndex, $CS_NumMandalorianAttacks, $CCS_MultiAttackTargets;
+  global $SET_PassDRStep, $CS_AbilityIndex, $CS_NumMandalorianAttacks, $CCS_MultiAttackTargets, $CS_SeparatistUnitsThatAttacked;
 
   $oppCardActive = GetClassState($currentPlayer, $CS_OppCardActive) > 0;
 
@@ -1810,6 +1810,7 @@ function PlayCardEffect($cardID, $from, $resourcesPaid, $target = "-", $addition
       if (!$chainClosed) {
         IncrementClassState($currentPlayer, $CS_NumAttacks);
         if(TraitContains($cardID, "Mandalorian", $currentPlayer, $index)) IncrementClassState($currentPlayer, $CS_NumMandalorianAttacks);
+        if(TraitContains($cardID, "Separatist", $currentPlayer, $index)) AppendClassState($currentPlayer, $CS_SeparatistUnitsThatAttacked, $ally->UniqueID(), false);
         ArsenalAttackAbilities();
         OnAttackEffects($cardID);
       }

--- a/Search.php
+++ b/Search.php
@@ -1088,3 +1088,15 @@ function GetUnitsThatAttackedBaseMZIndices($player) {//$player is the owner of t
   }
   return $unitsThatAttackedBaseMZIndices;
 }
+
+function AnotherSeparatistUnitHasAttacked($uniqueID, $player) {
+  global $CS_SeparatistUnitsThatAttacked;
+
+  $separatistUnitsThatAttacked = explode(",", GetClassState($player, $CS_SeparatistUnitsThatAttacked));
+
+  for($i = 0; $i < count($separatistUnitsThatAttacked); ++$i) {
+    if($separatistUnitsThatAttacked[$i] == "-") continue;
+    if($separatistUnitsThatAttacked[$i] != $uniqueID) return true;
+  }
+  return false;
+}


### PR DESCRIPTION
<img width=250 src=https://github.com/user-attachments/assets/c88fddf3-c41c-4415-99a4-2d2105ad897f>

### What does this PR do?

Automatically resolves the Asajj Ventress unit's on-attack trigger. Previously, the user had to answer a prompt about whether or not they had attacked with a Separatist unit up to that point.

#### Dev Notes:

My implementation uses patterns I saw from a couple other triggers (Bo-Katan tracks "Mandalorian" attacks, other units track units that have attacked a base). I'm new to the codebase and PHP in general, so please let me know if another strategy would be preferable!

#### Testing Notes:

I tested the following scenarios:

| Scenario | Expectation | Result |
| :--- | :--- | :---: |
| Attack with Asajj before any other attacks | No buff is given | ✅ Passed |
| Attack with a non-**Separatist** unit, then attack with Asajj | No buff is given | ✅ Passed |
| Attack with a **Separatist** unit, then attack with Asajj | Buff is given | ✅ Passed |
| Attack with the same Asajj unit twice in one phase (with Bravado & Frontline Shuttle) | No buff is given | ✅ Passed |
| Attack with two different Asajj units in the same phase | Buff is given to second Asajj unit only | ✅ Passed |
