### PR TITLE
fix: name of the player to go first in chat

### DIFF
--- a/APIs/ChooseFirstPlayer.php
+++ b/APIs/ChooseFirstPlayer.php
@@ -40,10 +40,12 @@ if ($authKey != $targetAuth) {
 
 if ($action == "Go First") {
   $firstPlayer = $playerID;
+  $firstPlayerName = $playerName;
 } else {
   $firstPlayer = ($playerID == 1 ? 2 : 1);
+  $firstPlayerName = $otherPlayerName;
 }
-WriteLog(FmtPlayer($playerName, $playerID) . " will go first.", path: "../");
+WriteLog(FmtPlayer($firstPlayerName, $firstPlayer) . " will go first.", path: "../");
 $gameStatus = $MGS_P2Sideboard;
 SetCachePiece($gameName, 14, $gameStatus);
 GamestateUpdated($gameName);

--- a/ChooseFirstPlayer.php
+++ b/ChooseFirstPlayer.php
@@ -25,10 +25,12 @@ if ($authKey != $targetAuth) {
 
 if ($action == "Go First") {
   $firstPlayer = $playerID;
+  $firstPlayerName = $playerName;
 } else {
   $firstPlayer = ($playerID == 1 ? 2 : 1);
+  $firstPlayerName = $otherPlayerName;
 }
-WriteLog(FmtPlayer($playerName, $playerID) . " will go first.");
+WriteLog(FmtPlayer($firstPlayerName, $firstPlayer) . " will go first.");
 $gameStatus = $MGS_P2Sideboard;
 SetCachePiece($gameName, 14, $gameStatus);
 GamestateUpdated($gameName);


### PR DESCRIPTION
This change fixes the name displayed in the chat/log when the player that won the dice roll decides whether to go first or second.